### PR TITLE
New expressions variables: mainLocation and returnedType

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,28 @@ ezplatform.query_fieldtype.routes:
 ```
 
 ## Usage
-Add a `query` field to a content type.
+Add a Content query field to a content type.
 
-In the Field Definition settings, select a Query Type out of the ones defined in the system, as well as the content type
-that is returned by that field.
+In the Field Definition settings, select a Query Type from the list, as well as the content type that is returned by that field.
 
-Parameters are used to get the query type's parameters, on runtime, based on properties from the content item.
-The syntax for it is YAML.. The key is the name of a query type parameter, and the value either a scalar, or an [expression](https://symfony.com/doc/current/components/expression_language.html).
+Parameters are used to build the query on runtime. They are either static, or mapped to properties from the content
+the field value belongs to. The syntax YAML, with the key being the name of a query type parameter, and the value
+either a scalar, or an [expression](https://symfony.com/doc/current/components/expression_language.html).
+
+The following variables are available for use in expressions:
+- `string returnedType`: the identifier of the content type that was previously selected
+- `eZ\Publish\API\Values\Content\Content content`: the current content item
+  Also gives you access to fields values. Example with an `ezurl` field: `@=content.getFieldValue('url').link`
+- `eZ\Publish\API\Values\Content\ContentInfo contentInfo`: the current content item's content info
+- `eZ\Publish\API\Values\Content\Location mainLocation`: the current content item's main location
 
 A simple example, for a LocationChildren query type that expects:
 - `parent_location_id`: id of the location to fetch children for
 - `content_types`: content type identifier or array of identifiers to filter on
 
 ````yaml
-parent_location_id: "@=content.contentInfo.mainLocationId"
-content_types: "image"
+parent_location_id: "@=mainLocation.id"
+content_types: "@=returnedType"
 ````
 
 See the [`examples`](doc/examples/) directory for full examples.

--- a/spec/API/QueryFieldServiceSpec.php
+++ b/spec/API/QueryFieldServiceSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\EzSystems\EzPlatformQueryFieldType\API;
 
+use eZ\Publish\API\Repository\LocationService;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldService;
 use EzSystems\EzPlatformQueryFieldType\FieldType\Query;
 use eZ\Publish\API\Repository\ContentTypeService;
@@ -28,6 +29,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
     function let(
         SearchService $searchService,
         ContentTypeService $contentTypeService,
+        LocationService $locationService,
         QueryTypeRegistry $queryTypeRegistry,
         QueryType $queryType
     ) {
@@ -58,7 +60,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
         $queryType->getQuery(Argument::any())->willReturn(new ApiQuery());
         // @todo this should fail. It does not.
         $searchService->findContent(Argument::any())->willReturn($this->searchResult);
-        $this->beConstructedWith($searchService, $contentTypeService, $queryTypeRegistry);
+        $this->beConstructedWith($searchService, $contentTypeService, $locationService, $queryTypeRegistry);
     }
 
     function it_is_initializable()

--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzPlatformQueryFieldType\API;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -27,14 +28,20 @@ final class QueryFieldService implements QueryFieldServiceInterface
 
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
+    /**
+     * @var \eZ\Publish\API\Repository\LocationService
+     */
+    private $locationService;
 
     public function __construct(
         SearchService $searchService,
         ContentTypeService $contentTypeService,
+        LocationService $locationService,
         QueryTypeRegistry $queryTypeRegistry
     ) {
         $this->searchService = $searchService;
         $this->contentTypeService = $contentTypeService;
+        $this->locationService = $locationService;
         $this->queryTypeRegistry = $queryTypeRegistry;
     }
 
@@ -105,12 +112,14 @@ final class QueryFieldService implements QueryFieldServiceInterface
             ->contentTypeService->loadContentType($content->contentInfo->contentTypeId)
             ->getFieldDefinition($fieldDefinitionIdentifier);
 
+        $location = $this->locationService->loadLocation($content->contentInfo->mainLocationId);
         $queryType = $this->queryTypeRegistry->getQueryType($fieldDefinition->fieldSettings['QueryType']);
         $parameters = $this->resolveParameters(
             $fieldDefinition->fieldSettings['Parameters'],
             [
                 'content' => $content,
                 'contentInfo' => $content->contentInfo,
+                'mainLocation' => $location,
                 'returnedType' => $fieldDefinition->fieldSettings['ReturnedType'],
             ]
         );

--- a/src/FieldType/Query/Type.php
+++ b/src/FieldType/Query/Type.php
@@ -195,7 +195,7 @@ final class Type extends FieldType
     {
         $errors = [];
 
-        if (isset($fieldSettings['QueryType']) && $fieldSettings['QueryType'] !== "") {
+        if (isset($fieldSettings['QueryType']) && $fieldSettings['QueryType'] !== '') {
             try {
                 $this->queryTypeRegistry->getQueryType($fieldSettings['QueryType']);
             } catch (InvalidArgumentException $e) {
@@ -203,7 +203,7 @@ final class Type extends FieldType
             }
         }
 
-        if (isset($fieldSettings['ReturnedType']) && $fieldSettings['ReturnedType'] !== "") {
+        if (isset($fieldSettings['ReturnedType']) && $fieldSettings['ReturnedType'] !== '') {
             try {
                 $this->contentTypeService->loadContentTypeByIdentifier($fieldSettings['ReturnedType']);
             } catch (NotFoundException $e) {


### PR DESCRIPTION
Adds two variables to the expression language used for parameters:
- `string returnedType`: identifier of the content type selected in the field definition
- `Location mainLocation`: main location of the field's content item