### PR TITLE
Changed rest routes pattern

### DIFF
--- a/src/Controller/QueryFieldRestController.php
+++ b/src/Controller/QueryFieldRestController.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformQueryFieldType\Controller;
 
+use eZ\Publish\Core\REST\Server\Values\TemporaryRedirect;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldService;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
@@ -15,6 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Server\Values\ContentList;
 use eZ\Publish\Core\REST\Server\Values\RestContent;
+use Symfony\Component\Routing\RouterInterface;
 
 final class QueryFieldRestController
 {
@@ -30,16 +32,21 @@ final class QueryFieldRestController
     /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
 
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
     public function __construct(
         QueryFieldService $queryFieldService,
         ContentService $contentService,
         ContentTypeService $contentTypeService,
-        LocationService $locationService
+        LocationService $locationService,
+        RouterInterface $router
     ) {
         $this->queryFieldService = $queryFieldService;
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
         $this->locationService = $locationService;
+        $this->router = $router;
     }
 
     public function getResults($contentId, $versionNumber, $fieldDefinitionIdentifier): ContentList
@@ -58,6 +65,20 @@ final class QueryFieldRestController
                     );
                 },
                 $this->queryFieldService->loadContentItems($content, $fieldDefinitionIdentifier)
+            )
+        );
+    }
+
+    public function redirectToResults(int $contentId, string $fieldDefinitionIdentifier)
+    {
+        return new TemporaryRedirect(
+            $this->router->generate(
+                'ezplatform_ezcontentquery_rest_field_version_items',
+                [
+                    'contentId' => $contentId,
+                    'versionNumber' => $this->contentService->loadContent($contentId)->versionInfo->versionNo,
+                    'fieldDefinitionIdentifier' => $fieldDefinitionIdentifier
+                ]
             )
         );
     }

--- a/src/Symfony/Resources/config/routing/rest.yml
+++ b/src/Symfony/Resources/config/routing/rest.yml
@@ -1,9 +1,18 @@
-ezpublish_rest_ezcontentquery_field_results:
-    path: /api/ezp/v2/content/objects/{contentId}/versions/{versionNumber}/fields/{fieldDefinitionIdentifier}/query/results
+ezplatform_ezcontentquery_rest_field_version_items:
+    path: /api/ezp/v2/content/objects/{contentId}/versions/{versionNumber}/fields/{fieldDefinitionIdentifier}/items
     defaults:
         _controller: EzSystems\EzPlatformQueryFieldType\Controller\QueryFieldRestController:getResults
     methods: [GET]
     requirements:
         contentId: \d+
-        fieldId: \d+
         versionNumber: \d+
+        fieldDefinitionIdentifier: \w+
+
+ezplatform_ezcontentquery_rest_field_currentversion_items:
+    path: /api/ezp/v2/content/objects/{contentId}/currentversion/fields/{fieldDefinitionIdentifier}/items
+    defaults:
+        _controller: EzSystems\EzPlatformQueryFieldType\Controller\QueryFieldRestController:redirectToResults
+    methods: [GET]
+    requirements:
+        contentId: \d+
+        fieldDefinitionIdentifier: \w+


### PR DESCRIPTION
- `/content/objects/{contentId}/currentversion/fields/{identifier}/items` redirects to the other route, with the current version number
- `/content/objects/{contentId}/versions/{versionNo}/fields/{identifier}/items` lists the items

### TODO
- [ ] What about route pattern conflicts ? The route above, besides the "items" part isn't specific to the query field. Isn't there a high chance of conflicts at some point ?