### PR TITLE
Named types

### DIFF
--- a/doc/research/named_field_types.md
+++ b/doc/research/named_field_types.md
@@ -1,0 +1,42 @@
+# Named query field types
+
+A higher level version of the query field type. Through configuration, queries are associated to a name. Those are added added to the list of available field types. When added, they query type isn't show, and the parameters are immediately displayed for editing. It saves time when modelling the content by allowing to reuse the same type for a similar concept.
+
+## Examples
+
+```
+ezplatform:
+  named_query_types:
+    children:
+      query_type: eZ:Children
+      default_parameters:
+        location: '@=location'
+        type: '@=returnedType'
+    relating_content:
+      query_type: eZ:ContentRelatedTo
+      default_parameters:
+        to_content: '@=content'
+        type: '@=returnedType'
+```
+
+## Extra features
+
+### Default query type parameters
+
+Content and location level (not field) based parameters can get a default value: the current content, its section, the returned type...
+
+### Translation
+
+That extra layer is a good place for translating parameters.
+
+### Customization
+
+Custom templates could be associated to named query field types, giving extra flexibility.
+
+### Extensibiliy
+
+Named queries make it easy for 3rd parties to add their own field types without developing any:
+
+- define new query types, with custom criteria if needed
+- define named queries
+

--- a/doc/research/named_field_types.md
+++ b/doc/research/named_field_types.md
@@ -10,7 +10,7 @@ ezplatform:
     children:
       query_type: eZ:Children
       default_parameters:
-        location: '@=location'
+        location: '@=mainLocation'
         type: '@=returnedType'
     relating_content:
       query_type: eZ:ContentRelatedTo

--- a/src/Symfony/DependencyInjection/EzSystemsEzPlatformQueryFieldTypeExtension.php
+++ b/src/Symfony/DependencyInjection/EzSystemsEzPlatformQueryFieldTypeExtension.php
@@ -116,7 +116,6 @@ final class EzSystemsEzPlatformQueryFieldTypeExtension extends Extension impleme
             // @todo validate name syntax
             $fieldTypeIdentifier = 'ezcontentquery_' . $name;
             
-            // tag the query field type service the identifier
             $this->defineFieldTypeService($container, $fieldTypeIdentifier, $config);
             $this->tagFieldTypeConverter($container, $fieldTypeIdentifier);
             $this->tagFieldTypeFormMapper($container, $config, $fieldTypeIdentifier);

--- a/src/Symfony/DependencyInjection/EzSystemsEzPlatformQueryFieldTypeExtension.php
+++ b/src/Symfony/DependencyInjection/EzSystemsEzPlatformQueryFieldTypeExtension.php
@@ -6,8 +6,12 @@
  */
 namespace EzSystems\EzPlatformQueryFieldType\Symfony\DependencyInjection;
 
+use EzSystems\EzPlatformQueryFieldType\eZ\FieldType\NamedQuery;
+use EzSystems\EzPlatformQueryFieldType\eZ\Persistence\Legacy\Content\FieldValue\Converter\QueryConverter;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
@@ -27,6 +31,7 @@ final class EzSystemsEzPlatformQueryFieldTypeExtension extends Extension impleme
         $loader->load('services.yml');
 
         $this->addContentViewConfig($container);
+        $this->handleNamedTypes($container);
     }
 
     public function prepend(ContainerBuilder $container)
@@ -99,5 +104,53 @@ final class EzSystemsEzPlatformQueryFieldTypeExtension extends Extension impleme
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('ezpublish', $config);
         $container->addResource(new FileResource($configFile));
+    }
+
+    private function handleNamedTypes(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('ezcontentquery_named')) {
+            return;
+        }
+        
+        foreach ($container->getParameter('ezcontentquery_named') as $name => $config) {
+            // @todo validate name syntax
+            $fieldTypeIdentifier = 'ezcontentquery_' . $name;
+            
+            // tag the query field type service the identifier
+            $this->defineFieldTypeService($container, $fieldTypeIdentifier, $config);
+            $this->tagFieldTypeConverter($container, $fieldTypeIdentifier);
+            $this->tagFieldTypeFormMapper($container, $config, $fieldTypeIdentifier);
+        }
+    }
+
+    private function defineFieldTypeService(ContainerBuilder $container, string $fieldTypeIdentifier, array $config)
+    {
+        $serviceId = NamedQuery\Type::class . '\\' . $fieldTypeIdentifier;
+
+        $definition = new ChildDefinition('ezpublish.fieldType');
+        $definition->setClass(NamedQuery\Type::class);
+        $definition->setAutowired(true);
+        $definition->setPublic(true);
+        $definition->addTag('ezpublish.fieldType', ['alias' => $fieldTypeIdentifier]);
+        $definition->setArgument('$identifier', $fieldTypeIdentifier);
+        $definition->setArgument('$config', $config);
+        $container->setDefinition($serviceId, $definition);
+    }
+
+    private function tagFieldTypeConverter(ContainerBuilder $container, string $fieldTypeIdentifier)
+    {
+        $container->getDefinition(QueryConverter::class)->addTag(
+            'ezpublish.storageEngine.legacy.converter',
+            ['alias' => $fieldTypeIdentifier]
+        );
+    }
+
+    private function tagFieldTypeFormMapper(ContainerBuilder $container, array $config, string $fieldTypeIdentifier)
+    {
+        $definition = new Definition(NamedQuery\Mapper::class);
+        $definition->addTag('ez.fieldFormMapper.definition', ['fieldType' => $fieldTypeIdentifier]);
+        $definition->setAutowired(true);
+        $definition->setArgument('$queryType', $config['query_type']);
+        $container->setDefinition(NamedQuery\Mapper::class . '\\' . $fieldTypeIdentifier, $definition);
     }
 }

--- a/src/Symfony/Resources/config/default_parameters.yml
+++ b/src/Symfony/Resources/config/default_parameters.yml
@@ -2,3 +2,14 @@ parameters:
     ezcontentquery_field_view: 'content_query_field'
     ezcontentquery_item_view: 'line'
     ezcontentquery_identifier: 'ezcontentquery'
+    ezcontentquery_named:
+        children:
+            query_type: eZ:Children
+            default_parameters:
+                location: 'mainLocation'
+                type: 'returnedType'
+        relating:
+            query_type: AppBundle:RelatedToContent
+            default_parameters:
+                to_content: 'content'
+                type: 'returnedType'

--- a/src/Symfony/Resources/config/services/ezplatform.yml
+++ b/src/Symfony/Resources/config/services/ezplatform.yml
@@ -41,3 +41,8 @@ services:
             $views: { field: '%ezcontentquery_field_view%', item: '%ezcontentquery_item_view%' }
         tags:
             - { name: kernel.event_subscriber }
+
+    EzSystems\EzPlatformQueryFieldType\eZ\Twig\QueryFieldBlockRenderer:
+        decorates: ezpublish.templating.field_block_renderer.twig
+        arguments:
+            $innerRenderer: '@EzSystems\EzPlatformQueryFieldType\eZ\Twig\QueryFieldBlockRenderer.inner'

--- a/src/Symfony/Resources/views/fieldtype/fielddefinition_edit.html.twig
+++ b/src/Symfony/Resources/views/fieldtype/fielddefinition_edit.html.twig
@@ -19,3 +19,17 @@
         {{- form_widget(form.Parameters) -}}
     </div>
 {% endblock %}
+
+{% block ezcontentquery_named_field_definition_edit %}
+    <div class="query-returned-type{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_label(form.ReturnedType) -}}
+        {{- form_errors(form.ReturnedType) -}}
+        {{- form_widget(form.ReturnedType) -}}
+    </div>
+
+    <div class="query-parameters{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_label(form.Parameters) -}}
+        {{- form_errors(form.Parameters) -}}
+        {{- form_widget(form.Parameters) -}}
+    </div>
+{% endblock %}

--- a/src/Symfony/Resources/views/fieldtype/fielddefinition_settings.html.html.twig
+++ b/src/Symfony/Resources/views/fieldtype/fielddefinition_settings.html.html.twig
@@ -21,3 +21,6 @@
         {{ block( 'settings_defaultvalue' ) }}
     </ul>
 {% endblock %}
+
+{% block ezcontentquery_named_settings %}
+{% endblock %}

--- a/src/eZ/FieldType/NamedQuery/Mapper.php
+++ b/src/eZ/FieldType/NamedQuery/Mapper.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\eZ\FieldType\NamedQuery;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+use EzSystems\EzPlatformQueryFieldType\eZ\FieldType\Mapper\ParametersTransformer;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class Mapper implements FieldDefinitionFormMapperInterface
+{
+    /** @var ContentTypeService */
+    private $contentTypeService;
+    /**
+     * @var string
+     */
+    private $queryType;
+    /**
+     * @var \eZ\Publish\Core\QueryType\QueryTypeRegistry
+     */
+    private $queryTypeRegistry;
+
+    public function __construct(ContentTypeService $contentTypeService, QueryTypeRegistry $queryTypeRegistry, string $queryType)
+    {
+        $this->contentTypeService = $contentTypeService;
+        $this->queryType = $queryType;
+        $this->queryTypeRegistry = $queryTypeRegistry;
+    }
+
+    public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
+    {
+        $parametersForm = $fieldDefinitionForm->getConfig()->getFormFactory()->createBuilder()
+            ->create(
+                'Parameters',
+                Type\TextareaType::class,
+                [
+                    'label' => 'Parameters',
+                    'property_path' => 'fieldSettings[Parameters]',
+                ]
+            )
+            ->addModelTransformer(new ParametersTransformer())
+            ->setAutoInitialize(false)
+            ->getForm();
+
+        $fieldDefinitionForm
+            ->add('ReturnedType', Type\ChoiceType::class,
+                [
+                    'label' => 'Returned type',
+                    'property_path' => 'fieldSettings[ReturnedType]',
+                    'choices' => $this->getContentTypes(),
+                    'required' => true,
+                ]
+            )
+            ->add($parametersForm);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'translation_domain' => 'ezrepoforms_content_type',
+            ]);
+    }
+
+    private function getContentTypes()
+    {
+        foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
+            foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
+                yield $contentType->getName() => $contentType->identifier;
+            }
+        }
+    }
+}

--- a/src/eZ/FieldType/NamedQuery/Type.php
+++ b/src/eZ/FieldType/NamedQuery/Type.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\eZ\FieldType\NamedQuery;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\FieldType\FieldType;
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+use eZ\Publish\SPI\FieldType\Value as SPIValue;
+use eZ\Publish\Core\FieldType\Value as BaseValue;
+
+final class Type extends FieldType
+{
+    protected $validatorConfigurationSchema = [];
+
+    protected $settingsSchema = [
+        'QueryType' => ['type' => 'string', 'default' => null],
+        'Parameters' => ['type' => 'array', 'default' => []],
+        'ReturnedType' => ['type' => 'string', 'default' => ''],
+    ];
+
+    /** @var \eZ\Publish\Core\QueryType\QueryTypeRegistry */
+    private $queryTypeRegistry;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var string */
+    private $identifier;
+
+    /** @var array */
+    private $config;
+
+    public function __construct(
+        QueryTypeRegistry $queryTypeRegistry,
+        ContentTypeService $contentTypeService,
+        string $identifier,
+        array $config
+    ) {
+        $this->queryTypeRegistry = $queryTypeRegistry;
+        $this->contentTypeService = $contentTypeService;
+        $this->identifier = $identifier;
+        // @todo error handling on $config
+        $this->config = $config;
+    }
+
+    public function applyDefaultSettings(&$fieldSettings)
+    {
+        parent::applyDefaultSettings($fieldSettings);
+        $fieldSettings['QueryType'] = $this->config['query_type'];
+        foreach ($this->config['default_parameters'] as $parameterName => $parameterValue) {
+            $fieldSettings['Parameters'][$parameterName] = '@=' . $parameterValue;
+        }
+    }
+
+    /**
+     * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
+     *
+     * @param mixed $validatorConfiguration
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValidatorConfiguration($validatorConfiguration)
+    {
+        $validationErrors = [];
+
+        return $validationErrors;
+    }
+
+    /**
+     * Validates a field based on the validators in the field definition.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
+     * @param \eZ\Publish\Core\FieldType\TextLine\Value $fieldValue The field value for which an action is performed
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    {
+        return [];
+    }
+
+    /**
+     * Returns the field type identifier for this field type.
+     *
+     * @return string
+     */
+    public function getFieldTypeIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Returns the name of the given field value.
+     *
+     * It will be used to generate content name and url alias if current field is designated
+     * to be used in the content name/urlAlias pattern.
+     *
+     * @param \EzSystems\EzPlatformQueryFieldType\eZ\FieldType\Query\Value $value
+     *
+     * @return string
+     */
+    public function getName(SPIValue $value)
+    {
+        return (string)$value->text;
+    }
+
+    public function getEmptyValue()
+    {
+        return new Value();
+    }
+
+    /**
+     * Returns if the given $value is considered empty by the field type.
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isEmptyValue(SPIValue $value)
+    {
+        return false;
+    }
+
+    protected function createValueFromInput($inputValue)
+    {
+        if (is_string($inputValue)) {
+            $inputValue = new Value($inputValue);
+        }
+
+        return $inputValue;
+    }
+
+    /**
+     * Throws an exception if value structure is not of expected format.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the value does not match the expected structure
+     *
+     * @param \eZ\Publish\Core\FieldType\TextLine\Value $value
+     */
+    protected function checkValueStructure(BaseValue $value)
+    {
+        if (!is_string($value->text)) {
+            throw new InvalidArgumentType(
+                '$value->text',
+                'string',
+                $value->text
+            );
+        }
+    }
+
+    /**
+     * Returns information for FieldValue->$sortKey relevant to the field type.
+     *
+     * @param \eZ\Publish\Core\FieldType\TextLine\Value $value
+     *
+     * @return array
+     */
+    protected function getSortInfo(BaseValue $value)
+    {
+        return $this->transformationProcessor->transformByGroup((string)$value, 'lowercase');
+    }
+
+    /**
+     * Converts an $hash to the Value defined by the field type.
+     *
+     * @param mixed $hash
+     *
+     * @return \eZ\Publish\Core\FieldType\TextLine\Value $value
+     */
+    public function fromHash($hash)
+    {
+        if ($hash === null) {
+            return $this->getEmptyValue();
+        }
+
+        return new Value($hash);
+    }
+
+    /**
+     * Converts a $Value to a hash.
+     *
+     * @param \eZ\Publish\Core\FieldType\TextLine\Value $value
+     *
+     * @return mixed
+     */
+    public function toHash(SPIValue $value)
+    {
+        if ($this->isEmptyValue($value)) {
+            return null;
+        }
+
+        return $value->text;
+    }
+
+    /**
+     * Returns whether the field type is searchable.
+     *
+     * @return bool
+     */
+    public function isSearchable()
+    {
+        return false;
+    }
+
+    public function validateFieldSettings($fieldSettings)
+    {
+        $errors = [];
+
+        if (isset($fieldSettings['QueryType']) && $fieldSettings['QueryType'] !== '') {
+            try {
+                $this->queryTypeRegistry->getQueryType($fieldSettings['QueryType']);
+            } catch (InvalidArgumentException $e) {
+                $errors[] = new ValidationError('The selected query type does not exist');
+            }
+        }
+
+        if (isset($fieldSettings['ReturnedType']) && $fieldSettings['ReturnedType'] !== '') {
+            try {
+                $this->contentTypeService->loadContentTypeByIdentifier($fieldSettings['ReturnedType']);
+            } catch (NotFoundException $e) {
+                $errors[] = new ValidationError('The selected returned type could not be loaded');
+            }
+        }
+
+        if (isset($fieldSettings['Parameters'])) {
+            if (!is_array($fieldSettings['Parameters'])) {
+                $errors[] = new ValidationError('Parameters is not a valid YAML string');
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/eZ/FieldType/NamedQuery/Value.php
+++ b/src/eZ/FieldType/NamedQuery/Value.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\eZ\FieldType\NamedQuery;
+
+use eZ\Publish\Core\FieldType\Value as BaseValue;
+
+class Value extends BaseValue
+{
+    /**
+     * Text content.
+     *
+     * @var string
+     */
+    public $text;
+
+    /**
+     * Construct a new Value object and initialize it $text.
+     *
+     * @param string $text
+     */
+    public function __construct($text = '')
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @see \eZ\Publish\Core\FieldType\Value
+     */
+    public function __toString()
+    {
+        return (string)$this->text;
+    }
+}

--- a/src/eZ/Twig/QueryFieldBlockRenderer.php
+++ b/src/eZ/Twig/QueryFieldBlockRenderer.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+
+namespace EzSystems\EzPlatformQueryFieldType\eZ\Twig;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\MVC\Symfony\Templating\FieldBlockRendererInterface;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition as CoreFieldDefinition;
+use Twig_Environment;
+use Twig_Template;
+
+/**
+ * Decorator for ezpublish-kernel's FieldBlockRenderer that handles named query field types.
+ */
+class QueryFieldBlockRenderer implements FieldBlockRendererInterface
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\Templating\FieldBlockRendererInterface */
+    private $innerRenderer;
+
+    public function __construct(FieldBlockRendererInterface $innerRenderer)
+    {
+        $this->innerRenderer = $innerRenderer;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function renderContentFieldView(Field $field, $fieldTypeIdentifier, array $params = [])
+    {
+        if ($this->isNamedQueryField($fieldTypeIdentifier)) {
+            $fieldTypeIdentifier = 'ezcontentquery';
+        }
+
+        return $this->innerRenderer->renderContentFieldView($field, $fieldTypeIdentifier, $params);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function renderContentFieldEdit(Field $field, $fieldTypeIdentifier, array $params = [])
+    {
+        if ($this->isNamedQueryField($fieldTypeIdentifier)) {
+            $fieldTypeIdentifier = 'ezcontentquery';
+        }
+
+        return $this->innerRenderer->renderContentFieldEdit($field, $fieldTypeIdentifier, $params);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function renderFieldDefinitionView(FieldDefinition $fieldDefinition, array $params = [])
+    {
+        if ($this->isNamedQueryField($fieldDefinition->fieldTypeIdentifier)) {
+            $fieldDefinition = $this->overrideFieldDefinition($fieldDefinition);
+        }
+
+        return $this->innerRenderer->renderFieldDefinitionEdit($fieldDefinition, $params);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function renderFieldDefinitionEdit(FieldDefinition $fieldDefinition, array $params = [])
+    {
+        if ($this->isNamedQueryField($fieldDefinition->fieldTypeIdentifier)) {
+            $fieldDefinition = $this->overrideFieldDefinition($fieldDefinition);
+        }
+
+        return $this->innerRenderer->renderFieldDefinitionEdit($fieldDefinition, $params);
+    }
+
+    private function isNamedQueryField($identifier): bool
+    {
+        return strpos($identifier, 'ezcontentquery_') === 0;
+    }
+
+    /**
+     * @param Twig_Environment $twig
+     */
+    public function setTwig(Twig_Environment $twig)
+    {
+        $this->innerRenderer->setTwig($twig);
+    }
+
+    /**
+     * @param string|Twig_Template $baseTemplate
+     */
+    public function setBaseTemplate($baseTemplate)
+    {
+        $this->innerRenderer->setBaseTemplate($baseTemplate);
+    }
+
+    /**
+     * @param array $fieldViewResources
+     */
+    public function setFieldViewResources(array $fieldViewResources = null)
+    {
+        $this->innerRenderer->setFieldViewResources($fieldViewResources);
+    }
+
+    /**
+     * @param array $fieldEditResources
+     */
+    public function setFieldEditResources(array $fieldEditResources = null)
+    {
+        $this->innerRenderer->setFieldEditResources($fieldEditResources);
+    }
+
+    /**
+     * @param array $fieldDefinitionViewResources
+     */
+    public function setFieldDefinitionViewResources(array $fieldDefinitionViewResources = null)
+    {
+        $this->innerRenderer->setFieldDefinitionViewResources($fieldDefinitionViewResources);
+    }
+
+    /**
+     * @param array $fieldDefinitionEditResources
+     */
+    public function setFieldDefinitionEditResources(array $fieldDefinitionEditResources = null)
+    {
+        $this->innerRenderer->setFieldDefinitionEditResources($fieldDefinitionEditResources);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition
+     */
+    protected function overrideFieldDefinition(FieldDefinition $fieldDefinition): FieldDefinition
+    {
+        $properties = [];
+        foreach ($fieldDefinition->attributes() as $property) {
+            $properties[$property] = $fieldDefinition->$property;
+        }
+        $properties['fieldTypeIdentifier'] = 'ezcontentquery_named';
+
+        return new CoreFieldDefinition($properties);
+    }
+}


### PR DESCRIPTION
This introduces a new layer on top of the query field: named query field types.

Using named configuration directives, extra query field types can be made available. They use a predefined query type, and can have default parameters.

Examples:
```
children:
    query_type: eZ:Children
    default_parameters:
        location: 'mainLocation'
        type: 'returnedType'
relating:
    query_type: AppBundle:RelatedToContent
    default_parameters:
        to_content: 'content'
        type: 'returnedType'
```

### Notes
- [ ] Consider renaming the "Query field type" to "Content list type". You don't care if it uses a query or something else when modelling content. Named types are then more natural: "Content list: children", "Content list: relating"