### PR TITLE
Fix EZP-31288: made the Identifier\FieldDefinition alias public

### DIFF
--- a/src/Symfony/Resources/config/services/ezplatform.yml
+++ b/src/Symfony/Resources/config/services/ezplatform.yml
@@ -34,7 +34,9 @@ services:
         calls:
             - [setRepository, ['@ezpublish.api.repository']]
 
-    Identifier\FieldDefinition: '@EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher'
+    Identifier\FieldDefinition:
+        alias: 'EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher'
+        public: true
 
     EzSystems\EzPlatformQueryFieldType\eZ\ContentView\QueryResultsInjector:
         arguments:


### PR DESCRIPTION
The alias used to match query fields definitions was not public, making it unusable as it gets loaded through the container.

Test by configuring a custom view for a query field:
```
ezpublish:
    system:
        default:
            content_view:
                content_query_field:
                    gallery_images:
                        match:
                            Identifier\ContentType: gallery
                            Identifier\FieldDefinition: images
                        template: "content/view/content_query_field/gallery_images.html.twig"
```