### PR TITLE
Fix EZP-31288: tagged the Identifier\FieldDefinition matcher as a view matcher

### DIFF
--- a/src/Symfony/Resources/config/services/ezplatform.yaml
+++ b/src/Symfony/Resources/config/services/ezplatform.yaml
@@ -27,13 +27,12 @@ services:
         tags:
             - { name: ezplatform.field_type.legacy_storage.converter, alias: '%ezcontentquery_identifier%' }
 
-    EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher:
+    Identifier\FieldDefinition:
+        class: EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher
         calls:
             - [setRepository, ['@ezpublish.api.repository']]
-
-    Identifier\FieldDefinition:
-        alias: 'EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher'
-        public: true
+        tags:
+            - { name: ezplatform.view.matcher }
 
     EzSystems\EzPlatformQueryFieldType\eZ\ContentView\QueryResultsInjector:
         arguments:


### PR DESCRIPTION
> JIRA: [EZP-31288](https://jira.ez.no/browse/EZP-31288)

The view matcher is now tagged as `ezplatform.view.matcher`. The long service name has also been removed, and replaced with the short name only, so that it is registered with that name in the registry.

Note that until [EZP-31290](https://jira.ez.no/browse/EZP-31290) ([pull-request](https://github.com/ezsystems/ezpublish-kernel/pull/2916)) is fixed, the matcher must be prefixed with `@` in the configuration:

```
match:
  '@Identifier\FieldDefinition': foo
```