### PR TITLE
Workaround for EZP-31288 (FieldDefinition Identifier matcher)

### DIFF
--- a/src/Symfony/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
+++ b/src/Symfony/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\Symfony\DependencyInjection\Compiler;
+
+use EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Replaces the short alias 'Identifier\FieldDefinition' by the matcher's service.
+ */
+class FieldDefinitionIdentifierViewMatcherPass implements CompilerPassInterface
+{
+    private const LONG_IDENTIFIER = '@' . FieldDefinitionIdentifierMatcher::class;
+    private const SHORT_IDENTIFIER = 'Identifier\FieldDefinition';
+
+    public function process(ContainerBuilder $container)
+    {
+        $configKeys = array_filter(
+            array_keys($container->getParameterBag()->all()),
+            function ($parameterName) {
+                return preg_match('/ezsettings\..+\.content_view/', $parameterName);
+            }
+        );
+
+        foreach ($configKeys as $configKey) {
+            $configuration = $container->getParameter($configKey);
+            foreach ($configuration as $viewType => $viewConfigurations) {
+                foreach ($viewConfigurations as $viewConfigurationName => $viewConfiguration) {
+                    if (isset($viewConfiguration['match'][self::SHORT_IDENTIFIER])) {
+                        $viewConfiguration['match'][self::LONG_IDENTIFIER] = $viewConfiguration['match'][self::SHORT_IDENTIFIER];
+                        unset($viewConfiguration['match'][self::SHORT_IDENTIFIER]);
+                        $configuration[$viewType][$viewConfigurationName] = $viewConfiguration;
+                    }
+                }
+            }
+            $container->setParameter($configKey, $configuration);
+        }
+    }
+}

--- a/src/Symfony/EzSystemsEzPlatformQueryFieldTypeBundle.php
+++ b/src/Symfony/EzSystemsEzPlatformQueryFieldTypeBundle.php
@@ -16,5 +16,6 @@ final class EzSystemsEzPlatformQueryFieldTypeBundle extends Bundle
     {
         $container->addCompilerPass(new Compiler\QueryTypesListPass());
         $container->addCompilerPass(new Compiler\ConfigurableFieldDefinitionMapperPass());
+        $container->addCompilerPass(new Compiler\FieldDefinitionIdentifierViewMatcherPass());
     }
 }

--- a/src/Symfony/Resources/config/services/ezplatform.yaml
+++ b/src/Symfony/Resources/config/services/ezplatform.yaml
@@ -28,12 +28,10 @@ services:
             - { name: ezplatform.field_type.legacy_storage.converter, alias: '%ezcontentquery_identifier%' }
 
     EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher:
+        tags:
+            - { name: ezplatform.view.matcher }
         calls:
             - [setRepository, ['@ezpublish.api.repository']]
-
-    Identifier\FieldDefinition:
-        alias: 'EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher'
-        public: true
 
     EzSystems\EzPlatformQueryFieldType\eZ\ContentView\QueryResultsInjector:
         arguments:


### PR DESCRIPTION
> [EZP-31288](https://jira.ez.no/browse/EZP-31288)

The short Field Definition Identifier matcher (`Identifier\FieldDefinition`) can not be supported in the current state of the 8.0 kernel (see https://github.com/ezsystems/ezpublish-kernel/pull/2916 for details and discussion). As it is what is documented, and because it is more convenient, it needs to be supported in the current beta.

The plan is to remove it once we have matchers with proper string literal identifiers.

I have also tried using decorators on various elements of the view matcher layer, but it is not suited for that unfortunately.

This pull-requests processes the semantic config using a compiler pass to replace the short identifier with the full service ID.