### PR TITLE
Pagination support (1.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.1",
         "ext-json": "*",
-        "ezsystems/ezplatform-graphql": "^1.0||^2.0",
+        "ezsystems/ezplatform-graphql": "^1.0@dev",
         "ezsystems/ezpublish-kernel": "^7.0||^8.0"
     },
     "autoload": {

--- a/doc/howto/customize_rendering.md
+++ b/doc/howto/customize_rendering.md
@@ -4,10 +4,16 @@ In this how-to, you will learn how to customize all the rendering phases.
 
 ## Rendering process
 Content query fields are rendered using `ez_render_field()`. 
-The query is executed, the items iterated on, and each is be displayed using the `line` content view.
+The query is executed, the items iterated on, and each is rendered using the `line` content view.
 
 That template renders the content, the view controller, with a custom view type (`content_query_view`). A custom view
 builder executes execute the query, and assigns the results to the view as `items`. The default template for that view (`query_field_view.html.twig`) iterates on each item resulting from the query, and renders each with the `line` view.
+
+The field renderer for a query field supports the following parameters:
+- `bool enablePagination`: force pagination enabled, even if it is disabled for that field definition
+- `bool disablePagination`: force pagination disabled, even if it is disabled for that field definition
+- `int itemsPerPage`: sets how many items are displayed per page with pagination. Required if `enablePagination` is
+  used and pagination is disabled in the field definition
 
 ### Summary
 1. Your template: `ez_render_field(content, 'queryfield')`
@@ -41,6 +47,7 @@ As with any content view, a custom controller can also be defined to further cus
 
 Use the `items` iterable to loop over the field's content items:
 ```
+<div class="my-list">
 {% for item in items %}
     {{ render(controller("ez_content:viewAction", {
         "contentId": item.id,
@@ -48,9 +55,19 @@ Use the `items` iterable to loop over the field's content items:
         "viewType": itemViewType
     })) }}
 {% endfor %}
+</div>
+
+{% if isPaginationEnabled %}
+    {{ pagerfanta( items, 'ez', {'routeName': location, 'pageParameter': pageParameter } ) }}
+{% endif %}
 ```
 
-The usual [content view templates variables](https://doc.ezplatform.com/en/latest/api/field_type_form_and_template/#template-variables) are also available, including `content`, the item that contains the query field.
+In addition to the [usual content view templates variables](https://doc.ezplatform.com/en/latest/api/field_type_form_and_template/#template-variables), the following variables are available:
+- `Content content`: the item that contains the query field.
+- `bool isPaginationEnabled`: indicates if pagination is enabled. When it is, `items` is a `PagerFanta` instance.
+- `string pageParameter`: when pagination is enabled, contains the page parameter to use as the pager fanta
+  `pageParameter` argument (important, as it makes every pager unique, required if there are several query
+  fields in the same item)
 
 ## Customizing the line view template
 The line view template, used to render each result, can be customized by creating `line` view configuration rules.
@@ -69,7 +86,7 @@ ezplatform:
                         template: "path/to/template.html.twig"                    
 ```
 
-The variables are the same as any view template ([documentation]((https://doc.ezplatform.com/en/latest/api/field_type_form_and_template/#template-variables))).
+The variables are the same than other view template ([documentation]((https://doc.ezplatform.com/en/latest/api/field_type_form_and_template/#template-variables))). 
 
 ## Advanced
 

--- a/spec/GraphQL/ContentQueryFieldDefinitionMapperSpec.php
+++ b/spec/GraphQL/ContentQueryFieldDefinitionMapperSpec.php
@@ -79,24 +79,38 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
             ->shouldBe('FieldValue');
     }
 
-    function it_delegates_the_value_resolver_to_the_parent_mapper(FieldDefinitionMapper $innerMapper)
+    function it_maps_the_field_value_when_pagination_is_disabled(FieldDefinitionMapper $innerMapper)
     {
         $fieldDefinition = $this->fieldDefinition();
-        $innerMapper->mapToFieldValueResolver($fieldDefinition)->willReturn('resolver');
+        $innerMapper->mapToFieldValueResolver($fieldDefinition)->shouldNotBeCalled();
         $this
             ->mapToFieldValueResolver($fieldDefinition)
-            ->shouldBe('resolver');
+            ->shouldBe('@=resolver("QueryFieldValue", [field, content])');
+    }
+
+    function it_maps_the_field_value_when_pagination_is_enabled(FieldDefinitionMapper $innerMapper)
+    {
+        $fieldDefinition = $this->fieldDefinition(true);
+        $innerMapper->mapToFieldValueResolver($fieldDefinition)->shouldNotBeCalled();
+        $this
+            ->mapToFieldValueResolver($fieldDefinition)
+            ->shouldBe('@=resolver("QueryFieldValueConnection", [args, field, content])');
     }
 
     /**
+     * @param bool $enablePagination
+     *
      * @return FieldDefinition
      */
-    private function fieldDefinition(): FieldDefinition
+    private function fieldDefinition(bool $enablePagination = false): FieldDefinition
     {
         return new FieldDefinition([
             'identifier' => self::FIELD_IDENTIFIER,
             'fieldTypeIdentifier' => self::FIELD_TYPE_IDENTIFIER,
-            'fieldSettings' => ['ReturnedType' => self::RETURNED_CONTENT_TYPE_IDENTIFIER]
+            'fieldSettings' => [
+                'ReturnedType' => self::RETURNED_CONTENT_TYPE_IDENTIFIER,
+                'EnablePagination' => $enablePagination
+             ]
         ]);
     }
 

--- a/src/API/QueryFieldPaginationService.php
+++ b/src/API/QueryFieldPaginationService.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\API;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+
+/**
+ * Pagination related methods for v1.0.
+ *
+ * @deprecated since 1.0, will be part of the regular QueryFieldService interface in 2.0.
+ */
+interface QueryFieldPaginationService
+{
+    public function getPaginationConfiguration(Content $content, string $fieldDefinitionIdentifier): int;
+
+    public function loadContentItemsSlice(Content $content, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable;
+}

--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -12,13 +12,14 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\QueryType\QueryTypeRegistry;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
  * Executes a query and returns the results.
  */
-final class QueryFieldService implements QueryFieldServiceInterface
+final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldPaginationService
 {
     /** @var \eZ\Publish\Core\QueryType\QueryTypeRegistry */
     private $queryTypeRegistry;
@@ -73,23 +74,48 @@ final class QueryFieldService implements QueryFieldServiceInterface
         return $this->searchService->findContent($query)->totalCount;
     }
 
+    public function loadContentItemsSlice(Content $content, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable
+    {
+        $query = $this->prepareQuery($content, $fieldDefinitionIdentifier);
+        $query->offset = $offset;
+        $query->limit = $limit;
+
+        return array_map(
+            function (SearchHit $searchHit) {
+                return $searchHit->valueObject;
+            },
+            $this->searchService->findContent($query)->searchHits
+        );
+    }
+
+    public function getPaginationConfiguration(Content $content, string $fieldDefinitionIdentifier): int
+    {
+        $fieldDefinition = $this->loadFieldDefinition($content, $fieldDefinitionIdentifier);
+
+        if ($fieldDefinition->fieldSettings['EnablePagination'] === false) {
+            return false;
+        }
+
+        return $fieldDefinition->fieldSettings['ItemsPerPage'];
+    }
+
     /**
-     * @param array $parameters parameters that may include expressions to be resolved
-     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param array $expressions parameters that may include expressions to be resolved
+     * @param array $variables
      *
      * @return array
      */
-    private function resolveParameters(array $parameters, array $variables): array
+    private function resolveParameters(array $expressions, array $variables): array
     {
-        foreach ($parameters as $key => $expression) {
+        foreach ($expressions as $key => $expression) {
             if (is_array($expression)) {
-                $parameters[$key] = $this->resolveParameters($expression, $variables);
+                $expressions[$key] = $this->resolveParameters($expression, $variables);
             } else {
-                $parameters[$key] = $this->resolveExpression($expression, $variables);
+                $expressions[$key] = $this->resolveExpression($expression, $variables);
             }
         }
 
-        return $parameters;
+        return $expressions;
     }
 
     private function resolveExpression(string $expression, array $variables)
@@ -110,24 +136,40 @@ final class QueryFieldService implements QueryFieldServiceInterface
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    private function prepareQuery(Content $content, string $fieldDefinitionIdentifier): Query
+    private function prepareQuery(Content $content, string $fieldDefinitionIdentifier, array $extraParameters = []): Query
     {
-        $fieldDefinition = $this
-            ->contentTypeService->loadContentType($content->contentInfo->contentTypeId)
-            ->getFieldDefinition($fieldDefinitionIdentifier);
+        $fieldDefinition = $this->loadFieldDefinition($content, $fieldDefinitionIdentifier);
 
         $location = $this->locationService->loadLocation($content->contentInfo->mainLocationId);
         $queryType = $this->queryTypeRegistry->getQueryType($fieldDefinition->fieldSettings['QueryType']);
         $parameters = $this->resolveParameters(
             $fieldDefinition->fieldSettings['Parameters'],
-            [
-                'content' => $content,
-                'contentInfo' => $content->contentInfo,
-                'mainLocation' => $location,
-                'returnedType' => $fieldDefinition->fieldSettings['ReturnedType'],
-            ]
+            array_merge(
+                $extraParameters,
+                [
+                    'content' => $content,
+                    'contentInfo' => $content->contentInfo,
+                    'mainLocation' => $location,
+                    'returnedType' => $fieldDefinition->fieldSettings['ReturnedType'],
+                ]
+            )
         );
 
         return $queryType->getQuery($parameters);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function loadFieldDefinition(Content $content, string $fieldDefinitionIdentifier): FieldDefinition
+    {
+        return $fieldDefinition = $this
+            ->contentTypeService->loadContentType($content->contentInfo->contentTypeId)
+            ->getFieldDefinition($fieldDefinitionIdentifier);
     }
 }

--- a/src/GraphQL/QueryFieldResolver.php
+++ b/src/GraphQL/QueryFieldResolver.php
@@ -6,9 +6,12 @@
  */
 namespace EzSystems\EzPlatformQueryFieldType\GraphQL;
 
+use EzSystems\EzPlatformQueryFieldType\API\QueryFieldPaginationService;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 
 final class QueryFieldResolver
 {
@@ -23,6 +26,28 @@ final class QueryFieldResolver
     public function resolveQueryField(Field $field, Content $content)
     {
         return $this->queryFieldService->loadContentItems($content, $field->fieldDefIdentifier);
+    }
+
+    public function resolveQueryFieldConnection(Argument $args, Field $field, Content $content)
+    {
+        if (!$this->queryFieldService instanceof QueryFieldPaginationService) {
+            throw new \Exception("The QueryFieldService isn't able to handle pagination, this should not happen");
+        }
+
+        if (!isset($args['first'])) {
+            $args['first'] = $this->queryFieldService->getPaginationConfiguration($content, $field->fieldDefIdentifier);
+        }
+
+        $paginator = new Paginator(function ($offset, $limit) use ($content, $field) {
+            return $this->queryFieldService->loadContentItemsSlice($content, $field->fieldDefIdentifier, $offset, $limit);
+        });
+
+        return $paginator->auto(
+            $args,
+            function () use ($content, $field) {
+                return $this->queryFieldService->countContentItems($content, $field->fieldDefIdentifier);
+            }
+        );
     }
 
     public function resolveQueryFieldDefinitionParameters(array $parameters): array

--- a/src/Symfony/Resources/config/services/graphql.yml
+++ b/src/Symfony/Resources/config/services/graphql.yml
@@ -7,9 +7,12 @@ services:
     EzSystems\EzPlatformQueryFieldType\GraphQL\QueryFieldResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "QueryFieldValue", method: "resolveQueryField" }
+            - { name: overblog_graphql.resolver, alias: "QueryFieldValueConnection", method: "resolveQueryFieldConnection" }
             - { name: overblog_graphql.resolver, alias: "QueryFieldDefinitionParameters", method: "resolveQueryFieldDefinitionParameters" }
 
     EzSystems\EzPlatformQueryFieldType\GraphQL\ContentQueryFieldDefinitionMapper:
         decorates: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
         arguments:
             $innerMapper: '@EzSystems\EzPlatformQueryFieldType\GraphQL\ContentQueryFieldDefinitionMapper.inner'
+        tags:
+            - { name: ezplatform_graphql.field_definition_args_builder_mapper, fieldtype: 'ezcontentquery' }

--- a/src/Symfony/Resources/views/content/contentquery.html.twig
+++ b/src/Symfony/Resources/views/content/contentquery.html.twig
@@ -6,3 +6,7 @@
         "viewType": itemViewType
     })) }}
 {% endfor %}
+
+{% if isPaginationEnabled %}
+    {{ pagerfanta( items, 'ez', {'routeName': location, 'pageParameter': pageParameter } ) }}
+{% endif %}

--- a/src/Symfony/Resources/views/fieldtype/field_view.html.twig
+++ b/src/Symfony/Resources/views/fieldtype/field_view.html.twig
@@ -7,7 +7,10 @@
         "contentId": contentInfo.id,
         "queryFieldDefinitionIdentifier": field.fieldDefIdentifier,
         "viewType": ezContentQueryViews['field'],
-        "itemViewType": itemViewType|default(ezContentQueryViews['item'])
+        "itemViewType": itemViewType|default(ezContentQueryViews['item']),
+        "enablePagination": parameters.enablePagination|default(false),
+        "disablePagination": parameters.disablePagination|default(false),
+        "itemsPerPage": parameters.itemsPerPage|default(false)
     }
 )) }}
 {% endblock %}

--- a/src/Symfony/Resources/views/fieldtype/fielddefinition_edit.html.twig
+++ b/src/Symfony/Resources/views/fieldtype/fielddefinition_edit.html.twig
@@ -13,6 +13,18 @@
         {{- form_widget(form.ReturnedType) -}}
     </div>
 
+    <div class="query-enable-pagination{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_label(form.EnablePagination) -}}
+        {{- form_errors(form.EnablePagination) -}}
+        {{- form_widget(form.EnablePagination) -}}
+    </div>
+
+    <div class="query-items-per-page{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_label(form.ItemsPerPage) -}}
+        {{- form_errors(form.ItemsPerPage) -}}
+        {{- form_widget(form.ItemsPerPage) -}}
+    </div>
+
     <div class="query-parameters{% if group_class is not empty %} {{ group_class }}{% endif %}">
         {{- form_label(form.Parameters) -}}
         {{- form_errors(form.Parameters) -}}

--- a/src/eZ/ContentView/QueryResultsInjector.php
+++ b/src/eZ/ContentView/QueryResultsInjector.php
@@ -8,8 +8,11 @@ namespace EzSystems\EzPlatformQueryFieldType\eZ\ContentView;
 
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
+use EzSystems\EzPlatformQueryFieldType\API\QueryFieldPaginationService;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldService;
+use Pagerfanta\Pagerfanta;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class QueryResultsInjector implements EventSubscriberInterface
 {
@@ -19,13 +22,18 @@ class QueryResultsInjector implements EventSubscriberInterface
     /** @var array */
     private $views;
 
-    public function __construct(QueryFieldService $queryFieldService, array $views)
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
+
+    public function __construct(QueryFieldService $queryFieldService, array $views, RequestStack $requestStack)
     {
-        $this->queryFieldService = $queryFieldService;
         if (!isset($views['item']) || !isset($views['field'])) {
             throw new \InvalidArgumentException("Both 'item' and 'field' views must be provided");
         }
+
+        $this->queryFieldService = $queryFieldService;
         $this->views = $views;
+        $this->requestStack = $requestStack;
     }
 
     public static function getSubscribedEvents()
@@ -41,14 +49,91 @@ class QueryResultsInjector implements EventSubscriberInterface
         $viewType = $event->getView()->getViewType();
 
         if ($viewType === $this->views['field']) {
-            $event->getParameterBag()->add([
+            $parameters = [
                 'itemViewType' => $this->views['item'],
-                'items' => $this->queryFieldService->loadContentItems(
-                    $event->getView()->getContent(),
-                    // @todo error handling if parameter not set
-                    $event->getBuilderParameters()['queryFieldDefinitionIdentifier']
-                ),
-            ]);
+                'items' => $this->buildResults($event),
+            ];
+            $parameters['isPaginationEnabled'] = ($parameters['items'] instanceof Pagerfanta);
+            if ($parameters['isPaginationEnabled']) {
+                $fieldDefinitionIdentifier = $event->getBuilderParameters()['queryFieldDefinitionIdentifier'];
+                $parameters['pageParameter'] = sprintf('[%s_page]', $fieldDefinitionIdentifier);
+            }
+            $event->getParameterBag()->add($parameters);
+        }
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewParametersEvent $event
+     *
+     * @return iterable
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    protected function buildResults(FilterViewParametersEvent $event): iterable
+    {
+        $view = $event->getView();
+        $content = $view->getContent();
+        $viewParameters = $event->getBuilderParameters();
+        $fieldDefinitionIdentifier = $viewParameters['queryFieldDefinitionIdentifier'];
+
+        $paginationLimit = false;
+
+        if ($this->queryFieldService instanceof QueryFieldPaginationService) {
+            $paginationLimit = $this->queryFieldService->getPaginationConfiguration($content, $fieldDefinitionIdentifier);
+        }
+
+        $enablePagination = ($viewParameters['enablePagination'] === true);
+        $disablePagination = ($viewParameters['disablePagination'] === true);
+
+        if ($enablePagination === true && $disablePagination === true) {
+            // @todo custom exception
+            throw new \InvalidArgumentException("the 'enablePagination' and 'disablePagination' parameters can not both be true");
+        }
+
+        if (is_numeric($viewParameters['itemsPerPage'])) {
+            // @todo custom exception
+            if ($viewParameters['itemsPerPage'] <= 0) {
+                throw new \InvalidArgumentException('itemsPerPage must be a positive integer');
+            }
+            $paginationLimit = $viewParameters['itemsPerPage'];
+        }
+
+        if (($enablePagination === true) && (!is_numeric($paginationLimit) || $paginationLimit === 0)) {
+            throw new \InvalidArgumentException("The 'itemsPerPage' parameter must be given with a positive integer value if 'enablePagination' is set");
+        }
+
+        if ($paginationLimit !== 0 && $disablePagination !== true) {
+            if (!$this->queryFieldService instanceof QueryFieldPaginationService) {
+                throw new \Exception(
+                    "Pagination was requested, but the QueryFieldService isn't an instance of %s",
+                    QueryFieldPaginationService::class
+                );
+            }
+
+            $request = $this->requestStack->getMasterRequest();
+
+            $queryParameters = $view->hasParameter('query') ? $view->getParameter('query') : [];
+
+            $limit = $queryParameters['limit'] ?? $paginationLimit;
+            $pageParam = sprintf('%s_page', $fieldDefinitionIdentifier);
+            $page = isset($request) ? $request->get($pageParam, 1) : 1;
+
+            $pager = new Pagerfanta(
+                new QueryResultsPagerFantaAdapter(
+                    $this->queryFieldService, $content, $fieldDefinitionIdentifier
+                )
+            );
+
+            $pager->setMaxPerPage($limit);
+            $pager->setCurrentPage($page);
+
+            return $pager;
+        } else {
+            // @todo error handling if parameter not set
+            return $this->queryFieldService->loadContentItems(
+                $content,
+                $fieldDefinitionIdentifier
+            );
         }
     }
 }

--- a/src/eZ/ContentView/QueryResultsPagerFantaAdapter.php
+++ b/src/eZ/ContentView/QueryResultsPagerFantaAdapter.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\eZ\ContentView;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use EzSystems\EzPlatformQueryFieldType\API\QueryFieldService;
+use Pagerfanta\Adapter\AdapterInterface;
+
+class QueryResultsPagerFantaAdapter implements AdapterInterface
+{
+    /** @var \EzSystems\EzPlatformQueryFieldType\API\QueryFieldService */
+    private $queryFieldService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Content */
+    private $content;
+
+    /** @var string */
+    private $fieldDefinitionIdentifier;
+
+    public function __construct(
+        QueryFieldService $queryFieldService,
+        Content $content,
+        string $fieldDefinitionIdentifier)
+    {
+        $this->queryFieldService = $queryFieldService;
+        $this->content = $content;
+        $this->fieldDefinitionIdentifier = $fieldDefinitionIdentifier;
+    }
+
+    public function getNbResults()
+    {
+        return $this->queryFieldService->countContentItems(
+            $this->content,
+            $this->fieldDefinitionIdentifier
+        );
+    }
+
+    public function getSlice($offset, $length)
+    {
+        return $this->queryFieldService->loadContentItemsSlice(
+            $this->content,
+            $this->fieldDefinitionIdentifier,
+            $offset,
+            $length
+        );
+    }
+}

--- a/src/eZ/FieldType/Mapper/QueryFormMapper.php
+++ b/src/eZ/FieldType/Mapper/QueryFormMapper.php
@@ -63,6 +63,19 @@ final class QueryFormMapper implements FieldDefinitionFormMapperInterface
                     'required' => true,
                 ]
             )
+            ->add('EnablePagination', Type\CheckboxType::class,
+                [
+                    'label' => 'Enable pagination',
+                    'property_path' => 'fieldSettings[EnablePagination]',
+                    'required' => false,
+                ]
+            )
+            ->add('ItemsPerPage', Type\NumberType::class,
+                [
+                    'label' => 'Items per page',
+                    'property_path' => 'fieldSettings[ItemsPerPage]',
+                ]
+            )
             ->add($parametersForm);
     }
 

--- a/src/eZ/FieldType/Query/Type.php
+++ b/src/eZ/FieldType/Query/Type.php
@@ -25,6 +25,8 @@ final class Type extends FieldType
         'QueryType' => ['type' => 'string', 'default' => ''],
         'Parameters' => ['type' => 'array', 'default' => []],
         'ReturnedType' => ['type' => 'string', 'default' => ''],
+        'EnablePagination' => ['type' => 'boolean', 'default' => true],
+        'ItemsPerPage' => ['type' => 'integer', 'default' => 10],
     ];
 
     /** @var \eZ\Publish\Core\QueryType\QueryTypeRegistry */
@@ -212,6 +214,18 @@ final class Type extends FieldType
                 $this->contentTypeService->loadContentTypeByIdentifier($fieldSettings['ReturnedType']);
             } catch (NotFoundException $e) {
                 $errors[] = new ValidationError('The selected returned type could not be loaded');
+            }
+        }
+
+        if (isset($fieldSettings['EnablePagination'])) {
+            if (!is_bool($fieldSettings['EnablePagination'])) {
+                $errors[] = new ValidationError('EnablePagination is not a boolean');
+            }
+        }
+
+        if (isset($fieldSettings['ItemsPerPage'])) {
+            if (!is_numeric($fieldSettings['ItemsPerPage'])) {
+                $errors[] = new ValidationError('ItemsPerPage is not an integer');
             }
         }
 

--- a/src/eZ/Persistence/Legacy/Content/FieldValue/Converter/QueryConverter.php
+++ b/src/eZ/Persistence/Legacy/Content/FieldValue/Converter/QueryConverter.php
@@ -63,6 +63,8 @@ class QueryConverter implements Converter
         $storageDef->dataText1 = $fieldDef->fieldTypeConstraints->fieldSettings['QueryType'];
         $storageDef->dataText2 = $fieldDef->fieldTypeConstraints->fieldSettings['ReturnedType'];
         $storageDef->dataText5 = \json_encode($fieldDef->fieldTypeConstraints->fieldSettings['Parameters']);
+        $storageDef->dataInt1 = (int)$fieldDef->fieldTypeConstraints->fieldSettings['EnablePagination'];
+        $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->fieldSettings['ItemsPerPage'];
     }
 
     /**
@@ -77,6 +79,8 @@ class QueryConverter implements Converter
             'QueryType' => $storageDef->dataText1 ?: null,
             'ReturnedType' => $storageDef->dataText2 ?: null,
             'Parameters' => \json_decode($storageDef->dataText5, true),
+            'EnablePagination' => (bool)$storageDef->dataInt1,
+            'ItemsPerPage' => $storageDef->dataInt2,
         ];
     }
 


### PR DESCRIPTION
> [EZP-31316](https://jira.ez.no/browse/EZP-31316)

Adds pagination support to the query field (1.0, eZ Platform 2.5).

## Implementation

### Field Type
Two new settings are added to the field type:
- a boolean, `EnablePagination`
- an integer, `ItemsPerPage`

### PHP
The `QueryFieldService` is extended with a `QueryFieldPaginationService`, with two new methods:
- `loadContentItemsSlice(Content $content, string $fieldDefinitionIdentifier, int $offset, int $limit)`: loads a slice of the results
- `getPaginationConfiguration(Content $content, string $fieldDefinitionIdentifier)`: returns either 0 if pagination is disabled, or the default page size

### Twig
When pagination is enabled for a field, the `QueryResultsInjector` (that adds the Query Field's results to the content view) will set `items` to a `PagerFanta` instance with a `QueryResultsPagerFantaAdapter`.

In addition, it will set two extra variables:
- `isPaginationEnabled`: boolean, used to conditionnally show the pager
- `pageParameter`: string, set to the unique page parameter used by the pager. It is named after the field definition identifier. Example: `[images_page]`.

### REST
The REST route for query field results now supports `offset` and `limit` parameters.

### GraphQL
If a field definition has pagination enabled, the field will return a `Connection` of that type, with the usual arguments (`first`, `last`, `after`, `before`). If no parameter is specified, it will use the items per page option from the field definition.

## TODO
- [x] Custom pagination arguments for `ez_render_field`
- [ ] Consider improving the `getPaginationConfiguration()` method (the naming is a bit off)
- [x] Expose the total results count over REST (see https://github.com/ezsystems/ezplatform-query-fieldtype/pull/20)