### PR TITLE
Fix EZP-31364: removed checks on deprecated QueryFieldPaginationService

### DIFF
--- a/src/GraphQL/QueryFieldResolver.php
+++ b/src/GraphQL/QueryFieldResolver.php
@@ -6,7 +6,6 @@
  */
 namespace EzSystems\EzPlatformQueryFieldType\GraphQL;
 
-use EzSystems\EzPlatformQueryFieldType\API\QueryFieldPaginationService;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
@@ -30,10 +29,6 @@ final class QueryFieldResolver
 
     public function resolveQueryFieldConnection(Argument $args, Field $field, Content $content)
     {
-        if (!$this->queryFieldService instanceof QueryFieldPaginationService) {
-            throw new \Exception("The QueryFieldService isn't able to handle pagination, this should not happen");
-        }
-
         if (!isset($args['first'])) {
             $args['first'] = $this->queryFieldService->getPaginationConfiguration($content, $field->fieldDefIdentifier);
         }

--- a/src/eZ/ContentView/QueryResultsInjector.php
+++ b/src/eZ/ContentView/QueryResultsInjector.php
@@ -8,7 +8,6 @@ namespace EzSystems\EzPlatformQueryFieldType\eZ\ContentView;
 
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
-use EzSystems\EzPlatformQueryFieldType\API\QueryFieldPaginationService;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldService;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -76,12 +75,7 @@ final class QueryResultsInjector implements EventSubscriberInterface
         $viewParameters = $event->getBuilderParameters();
         $fieldDefinitionIdentifier = $viewParameters['queryFieldDefinitionIdentifier'];
 
-        $paginationLimit = false;
-
-        if ($this->queryFieldService instanceof QueryFieldPaginationService) {
-            $paginationLimit = $this->queryFieldService->getPaginationConfiguration($content, $fieldDefinitionIdentifier);
-        }
-
+        $paginationLimit = $this->queryFieldService->getPaginationConfiguration($content, $fieldDefinitionIdentifier);
         $enablePagination = ($viewParameters['enablePagination'] === true);
         $disablePagination = ($viewParameters['disablePagination'] === true);
 
@@ -103,13 +97,6 @@ final class QueryResultsInjector implements EventSubscriberInterface
         }
 
         if ($paginationLimit !== 0 && $disablePagination !== true) {
-            if (!$this->queryFieldService instanceof QueryFieldPaginationService) {
-                throw new \Exception(
-                    "Pagination was requested, but the QueryFieldService isn't an instance of %s",
-                    QueryFieldPaginationService::class
-                );
-            }
-
             $request = $this->requestStack->getMasterRequest();
 
             $queryParameters = $view->hasParameter('query') ? $view->getParameter('query') : [];


### PR DESCRIPTION
> Fixes [EZP-31364](https://jira.ez.no/browse/EZP-31364)

Removes checks on the deprecated interface `QueryFieldPaginationService`. They were failing because the `QueryFieldService` doesn't implement it in 2.0. They should have been removed when merging from 1.0 anyway.