### PR TITLE
Fix EZP-31364: throw a 404 if requested field doesn't exist

### DIFF
--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\QueryType\QueryTypeRegistry;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
@@ -168,8 +169,16 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldP
      */
     private function loadFieldDefinition(Content $content, string $fieldDefinitionIdentifier): FieldDefinition
     {
-        return $fieldDefinition = $this
-            ->contentTypeService->loadContentType($content->contentInfo->contentTypeId)
-            ->getFieldDefinition($fieldDefinitionIdentifier);
+        $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
+        $fieldDefinition = $contentType->getFieldDefinition($fieldDefinitionIdentifier);
+
+        if ($fieldDefinition === null) {
+            throw new NotFoundException(
+                'Query field definition',
+                $contentType->identifier . '/' . $fieldDefinitionIdentifier
+            );
+        }
+
+        return $fieldDefinition;
     }
 }


### PR DESCRIPTION
> Fixes [EZP-31365](https://jira.ez.no/browse/EZP-31365)

When the results from a query field are requested, but the content doesn't have such a field, a 500 error occurs. With this fix, a proper 404 explaining the issue is returned.

```json
{
    "ErrorMessage": {
        "_media-type": "application/vnd.ez.api.ErrorMessage+json",
        "errorCode": 404,
        "errorMessage": "Not Found",
        "errorDescription": "Could not find 'Query field definition' with identifier 'folder/images'",
    }
}
```

To test, call the query field REST source with the ID of a content that does not have the requested query field definition identifier:

```
https://example.com/api/ezp/v2/content/objects/1/versions/9/fields/images/query/results
```

### TODO
- [ ] Merge to master as well