### PR TITLE
Fixed EZP-31364: wrong exception ctor call

### DIFF
--- a/src/eZ/ContentView/QueryResultsInjector.php
+++ b/src/eZ/ContentView/QueryResultsInjector.php
@@ -102,12 +102,12 @@ class QueryResultsInjector implements EventSubscriberInterface
             throw new \InvalidArgumentException("The 'itemsPerPage' parameter must be given with a positive integer value if 'enablePagination' is set");
         }
 
-        if ($paginationLimit !== 0 && $disablePagination !== true) {
+        if ($paginationLimit !== false && $paginationLimit !== 0 && $disablePagination !== true) {
             if (!$this->queryFieldService instanceof QueryFieldPaginationService) {
-                throw new \Exception(
+                throw new \Exception(sprintf(
                     "Pagination was requested, but the QueryFieldService isn't an instance of %s",
                     QueryFieldPaginationService::class
-                );
+                ));
             }
 
             $request = $this->requestStack->getMasterRequest();


### PR DESCRIPTION
> Fixes [EZP-31364](https://jira.ez.no/browse/EZP-31364)

An exception constructor had the wrong number of arguments because of a missing `sprintf()`. Fixed for 2.0 in https://github.com/ezsystems/ezplatform-query-fieldtype/pull/23.