### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,12 @@
         }
     },
     "require-dev": {
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
+        "ezsystems/ez-support-tools": "^2.0@dev",
+        "ezsystems/ezplatform-admin-ui-modules": "^2.0@dev",
+        "ezsystems/ezplatform-design-engine": "^3.0@dev",
+        "ezsystems/ezplatform-richtext": "^2.0@dev",
+        "ezsystems/ezplatform-user": "^2.0@dev",
         "phpspec/phpspec": "^6.0",
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
         "ezsystems/ezplatform-graphql": "^2.0@dev",
         "ezsystems/ezplatform-rest": "^1.0@dev",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "symfony/dependency-injection": "^5.0",
         "symfony/expression-language": "^5.0",
         "symfony/event-dispatcher": "^5.0",

--- a/spec/API/QueryFieldServiceSpec.php
+++ b/spec/API/QueryFieldServiceSpec.php
@@ -20,6 +20,7 @@ use Prophecy\Argument;
 class QueryFieldServiceSpec extends ObjectBehavior
 {
     const CONTENT_TYPE_ID = 1;
+    const LOCATION_ID = 1;
     const QUERY_TYPE_IDENTIFIER = 'query_type_identifier';
     const FIELD_DEFINITION_IDENTIFIER = 'test';
 
@@ -55,8 +56,12 @@ class QueryFieldServiceSpec extends ObjectBehavior
                 ]),
             ]),
         ]);
+        $location = new Values\Content\Location([
+            'id' => self::LOCATION_ID
+        ]);
 
         $contentTypeService->loadContentType(self::CONTENT_TYPE_ID)->willReturn($contentType);
+        $locationService->loadLocation(self::LOCATION_ID)->willReturn($location);
         $queryTypeRegistry->getQueryType(self::QUERY_TYPE_IDENTIFIER)->willReturn($queryType);
         $queryType->getQuery(Argument::any())->willReturn(new ApiQuery());
         // @todo this should fail. It does not.
@@ -86,7 +91,10 @@ class QueryFieldServiceSpec extends ObjectBehavior
     {
         return new Values\Content\Content([
             'versionInfo' => new Values\Content\VersionInfo([
-                'contentInfo' => new ContentInfo(['contentTypeId' => self::CONTENT_TYPE_ID]),
+                'contentInfo' => new ContentInfo([
+                    'contentTypeId' => self::CONTENT_TYPE_ID,
+                    'mainLocationId' => self::LOCATION_ID,
+                ]),
             ])
         ]);
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`
- other packages are required by `ezsystems/ezplatform-admin-ui:^2.0@dev`

#### TODO
- [x] Wait for Travis