### PR TITLE
Fix EZP-31514: use _ez_content_view route for pagerfanta

### DIFF
--- a/src/Symfony/Resources/views/content/contentquery.html.twig
+++ b/src/Symfony/Resources/views/content/contentquery.html.twig
@@ -8,5 +8,9 @@
 {% endfor %}
 
 {% if isPaginationEnabled %}
-    {{ pagerfanta( items, 'ez', {'routeName': location, 'pageParameter': pageParameter } ) }}
+    {{ pagerfanta( items, 'ez', {
+        'pageParameter': pageParameter,
+        'routeName': '_ez_content_view',
+        'routeParams' : {'contentId': content.id, 'locationId': location.id }
+    } ) }}
 {% endif %}


### PR DESCRIPTION
> Fixes [EZP-31514](https://jira.ez.no/browse/EZP-31514)

Instead of using the `location` object as the argument for the pager, it uses `_ez_content_view` with the `contentId` and `locationId` arguments.

The documentation needs to be updated for customizing the pager.