### PR TITLE
EZP-31556: Contentquery field type fails with Solr Bundle enabled

### DIFF
--- a/src/Symfony/Resources/config/services/ezplatform.yaml
+++ b/src/Symfony/Resources/config/services/ezplatform.yaml
@@ -38,3 +38,8 @@ services:
             $views: { field: '%ezcontentquery_field_view%', item: '%ezcontentquery_item_view%' }
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish.fieldType.indexable.unindexed:
+        class: eZ\Publish\Core\FieldType\Unindexed
+        tags:
+            - {name: ezplatform.field_type.indexable, alias: ezcontentquery}


### PR DESCRIPTION
Jira ticket: https://jira.ez.no/browse/EZP-31556

The content query field type is not searchable. This is as expected, and works when using the standard SQL backend. But as of now this fails when Solr bundle is because there is no search implementation.

This PR adds configuration to use `eZ\Publish\Core\FieldType\Unindexed` to make Solr indexing great again.