### PR TITLE
Support for getting the results for a location

### DIFF
--- a/spec/API/QueryFieldServiceSpec.php
+++ b/spec/API/QueryFieldServiceSpec.php
@@ -23,6 +23,7 @@ use Prophecy\Argument;
 class QueryFieldServiceSpec extends ObjectBehavior
 {
     const CONTENT_TYPE_ID = 1;
+    const CONTENT_TYPE_ID_WITHOUT_PAGINATION = 2;
     const LOCATION_ID = 1;
     const QUERY_TYPE_IDENTIFIER = 'query_type_identifier';
     const FIELD_DEFINITION_IDENTIFIER = 'test';
@@ -46,24 +47,16 @@ class QueryFieldServiceSpec extends ObjectBehavior
             'param2' => 'value2',
         ];
 
-        $contentType = new Values\ContentType\ContentType([
-            'fieldDefinitions' => new Values\ContentType\FieldDefinitionCollection([
-                new Values\ContentType\FieldDefinition([
-                    'identifier' => self::FIELD_DEFINITION_IDENTIFIER,
-                    'fieldTypeIdentifier' => 'ezcontentquery',
-                    'fieldSettings' => [
-                        'ReturnedType' => 'folder',
-                        'QueryType' => self::QUERY_TYPE_IDENTIFIER,
-                        'Parameters' => $parameters,
-                    ],
-                ]),
-            ]),
-        ]);
         $location = new Values\Content\Location([
             'id' => self::LOCATION_ID,
         ]);
 
-        $contentTypeService->loadContentType(self::CONTENT_TYPE_ID)->willReturn($contentType);
+        $contentTypeWithPagination = $this->getContentType($parameters);
+        $contentTypeService->loadContentType(self::CONTENT_TYPE_ID)->willReturn($contentTypeWithPagination);
+
+        $contentTypeWithoutPagination = $this->getContentType($parameters, false, 10);
+        $contentTypeService->loadContentType(self::CONTENT_TYPE_ID_WITHOUT_PAGINATION)->willReturn($contentTypeWithoutPagination);
+
         $locationService->loadLocation(self::LOCATION_ID)->willReturn($location);
         $queryTypeRegistry->getQueryType(self::QUERY_TYPE_IDENTIFIER)->willReturn($queryType);
         $queryType->getQuery(Argument::any())->willReturn(new ApiQuery());
@@ -113,15 +106,31 @@ class QueryFieldServiceSpec extends ObjectBehavior
         $this->countContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe(0);
     }
 
+    function it_returns_0_as_pagination_configuration_if_pagination_is_disabled()
+    {
+        $this->getPaginationConfiguration(
+            $this->getContent(self::CONTENT_TYPE_ID_WITHOUT_PAGINATION),
+            self::FIELD_DEFINITION_IDENTIFIER
+        )->shouldBe(0);
+    }
+
+    function it_returns_the_items_per_page_number_as_pagination_configuration_if_pagination_is_enabled()
+    {
+        $this->getPaginationConfiguration(
+            $this->getContent(),
+            self::FIELD_DEFINITION_IDENTIFIER
+        )->shouldBe(10);
+    }
+
     /**
      * @return \eZ\Publish\Core\Repository\Values\Content\Content
      */
-    private function getContent(): Values\Content\Content
+    private function getContent(int $contentTypeId = self::CONTENT_TYPE_ID): Values\Content\Content
     {
         return new Values\Content\Content([
             'versionInfo' => new Values\Content\VersionInfo([
                 'contentInfo' => new ContentInfo([
-                    'contentTypeId' => self::CONTENT_TYPE_ID,
+                    'contentTypeId' => $contentTypeId,
                     'mainLocationId' => self::LOCATION_ID,
                     'mainLocation' => new Values\Content\Location([
                         'id' => self::LOCATION_ID,

--- a/spec/API/QueryFieldServiceSpec.php
+++ b/spec/API/QueryFieldServiceSpec.php
@@ -123,8 +123,37 @@ class QueryFieldServiceSpec extends ObjectBehavior
                 'contentInfo' => new ContentInfo([
                     'contentTypeId' => self::CONTENT_TYPE_ID,
                     'mainLocationId' => self::LOCATION_ID,
+                    'mainLocation' => new Values\Content\Location([
+                        'id' => self::LOCATION_ID,
+                    ]),
                 ]),
             ]),
         ]);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    private function getContentType(array $parameters, bool $enablePagination = true, $itemsPerPage = 10): \eZ\Publish\API\Repository\Values\ContentType\ContentType
+    {
+        $contentType = new Values\ContentType\ContentType([
+            'fieldDefinitions' => new Values\ContentType\FieldDefinitionCollection([
+                new Values\ContentType\FieldDefinition([
+                    'identifier' => self::FIELD_DEFINITION_IDENTIFIER,
+                    'fieldTypeIdentifier' => 'ezcontentquery',
+                    'fieldSettings' => [
+                        'ReturnedType' => 'folder',
+                        'QueryType' => self::QUERY_TYPE_IDENTIFIER,
+                        'EnablePagination' => $enablePagination,
+                        'ItemsPerPage' => $itemsPerPage,
+                        'Parameters' => $parameters,
+                    ],
+                ]),
+            ]),
+        ]);
+
+        return $contentType;
     }
 }

--- a/src/API/QueryFieldLocationService.php
+++ b/src/API/QueryFieldLocationService.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\API;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+/**
+ * Executes queries for a query field for a given a location.
+ */
+interface QueryFieldLocationService
+{
+    /**
+     * Returns the query results for the given location.
+     *
+     * @return iterable An iterable that yields Content items.
+     */
+    public function loadContentItemsForLocation(Location $location, string $fieldDefinitionIdentifier): iterable;
+
+    /**
+     * Returns a slice of the query results for the given location.
+     *
+     * @return iterable An iterable that yields Content items.
+     */
+    public function loadContentItemsSliceForLocation(Location $location, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable;
+
+    /**
+     * Counts the results for the given location.
+     */
+    public function countContentItemsForLocation(Location $location, string $fieldDefinitionIdentifier): int;
+}

--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -106,7 +106,7 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
         $fieldDefinition = $this->loadFieldDefinition($content, $fieldDefinitionIdentifier);
 
         if ($fieldDefinition->fieldSettings['EnablePagination'] === false) {
-            return false;
+            return 0;
         }
 
         return $fieldDefinition->fieldSettings['ItemsPerPage'];

--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -114,9 +114,6 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
 
     /**
      * @param array $expressions parameters that may include expressions to be resolved
-     * @param array $variables
-     *
-     * @return array
      */
     private function resolveParameters(array $expressions, array $variables): array
     {
@@ -139,11 +136,6 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
     }
 
     /**
-     * @param string $expression
-     * @param array $variables
-     *
-     * @return mixed
-     *
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if $expression is not an expression.
      */
     private function resolveExpression(string $expression, array $variables)
@@ -178,11 +170,6 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
-     * @param string $fieldDefinitionIdentifier
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     private function loadFieldDefinition(Content $content, string $fieldDefinitionIdentifier): FieldDefinition

--- a/src/API/QueryFieldServiceInterface.php
+++ b/src/API/QueryFieldServiceInterface.php
@@ -52,12 +52,10 @@ interface QueryFieldServiceInterface
     public function loadContentItemsSlice(Content $content, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable;
 
     /**
-     * Returns the configured items per page for a query field definition, or false if pagination is disabled.
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param string $fieldDefinitionIdentifier
      *
-     * @return int|false
+     * @return int The page size, or 0 if pagination is disabled.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */

--- a/src/API/QueryFieldServiceInterface.php
+++ b/src/API/QueryFieldServiceInterface.php
@@ -9,12 +9,14 @@ namespace EzSystems\EzPlatformQueryFieldType\API;
 use eZ\Publish\API\Repository\Values\Content\Content;
 
 /**
- * Executes a query and returns the results.
+ * Executes queries for a query field.
  */
 interface QueryFieldServiceInterface
 {
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * Executes the query without pagination and returns the content items.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $content
      * @param string $fieldDefinitionIdentifier
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content[]
@@ -24,16 +26,40 @@ interface QueryFieldServiceInterface
     public function loadContentItems(Content $content, string $fieldDefinitionIdentifier): iterable;
 
     /**
+     * Counts the total results of a query.
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param string $fieldDefinitionIdentifier
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     * @return int
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function countContentItems(Content $content, string $fieldDefinitionIdentifier): int;
 
+    /**
+     * Executes a paginated query and return the requested content items slice.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param string $fieldDefinitionIdentifier
+     * @param int $offset
+     * @param int $limit
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
     public function loadContentItemsSlice(Content $content, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable;
 
-    public function getPaginationConfiguration(Content $content, string $fieldDefinitionIdentifier): int;
+    /**
+     * Returns the configured items per page for a query field definition, or false if pagination is disabled.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return int|false
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getPaginationConfiguration($content, string $fieldDefinitionIdentifier): int;
 }

--- a/src/API/QueryFieldServiceInterface.php
+++ b/src/API/QueryFieldServiceInterface.php
@@ -61,5 +61,5 @@ interface QueryFieldServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    public function getPaginationConfiguration($content, string $fieldDefinitionIdentifier): int;
+    public function getPaginationConfiguration(Content $content, string $fieldDefinitionIdentifier): int;
 }

--- a/src/Symfony/Resources/config/services/services.yaml
+++ b/src/Symfony/Resources/config/services/services.yaml
@@ -4,7 +4,9 @@ services:
         autowire: true
         public: true
 
-    EzSystems\EzPlatformQueryFieldType\Controller\QueryFieldRestController: ~
+    EzSystems\EzPlatformQueryFieldType\Controller\QueryFieldRestController:
+        arguments:
+            $requestParser: '@ezpublish_rest.request_parser'
 
     EzSystems\EzPlatformQueryFieldType\API\QueryFieldService:
         arguments:

--- a/src/Symfony/Resources/views/fieldtype/field_view.html.twig
+++ b/src/Symfony/Resources/views/fieldtype/field_view.html.twig
@@ -4,7 +4,8 @@
 {{ render(controller(
     "ez_content:viewAction",
     {
-        "contentId": contentInfo.id,
+        "content": content,
+        "location": location ?? null,
         "queryFieldDefinitionIdentifier": field.fieldDefIdentifier,
         "viewType": ezContentQueryViews['field'],
         "itemViewType": itemViewType|default(ezContentQueryViews['item']),

--- a/src/eZ/ContentView/QueryResultsInjector.php
+++ b/src/eZ/ContentView/QueryResultsInjector.php
@@ -118,11 +118,19 @@ final class QueryResultsInjector implements EventSubscriberInterface
             $pageParam = sprintf('%s_page', $fieldDefinitionIdentifier);
             $page = isset($request) ? $request->get($pageParam, 1) : 1;
 
-            $pager = new Pagerfanta(
-                new QueryResultsPagerFantaAdapter(
-                    $this->queryFieldService, $content, $fieldDefinitionIdentifier
-                )
-            );
+            if (isset($location)) {
+                $pager = new Pagerfanta(
+                    new QueryResultsWithLocationPagerFantaAdapter(
+                        $this->queryFieldService, $location, $fieldDefinitionIdentifier
+                    )
+                );
+            } else {
+                $pager = new Pagerfanta(
+                    new QueryResultsPagerFantaAdapter(
+                        $this->queryFieldService, $content, $fieldDefinitionIdentifier
+                    )
+                );
+            }
 
             $pager->setMaxPerPage($limit);
             $pager->setCurrentPage($page);

--- a/src/eZ/ContentView/QueryResultsInjector.php
+++ b/src/eZ/ContentView/QueryResultsInjector.php
@@ -77,13 +77,8 @@ final class QueryResultsInjector implements EventSubscriberInterface
     private function buildResults(FilterViewParametersEvent $event): iterable
     {
         $view = $event->getView();
-        if ($view instanceof LocationValueView) {
-            $location = $view->getLocation();
-        }
-
-        if ($view instanceof ContentValueView) {
-            $content = $view->getContent();
-        }
+        $location = $view instanceof LocationValueView ? $location = $view->getLocation() : null;
+        $content = $view instanceof ContentValueView ? $view->getContent() : null;
 
         $viewParameters = $event->getBuilderParameters();
         $fieldDefinitionIdentifier = $viewParameters['queryFieldDefinitionIdentifier'];
@@ -118,7 +113,7 @@ final class QueryResultsInjector implements EventSubscriberInterface
             $pageParam = sprintf('%s_page', $fieldDefinitionIdentifier);
             $page = isset($request) ? $request->get($pageParam, 1) : 1;
 
-            if (isset($location)) {
+            if ($location !== null) {
                 $pager = new Pagerfanta(
                     new QueryResultsWithLocationPagerFantaAdapter(
                         $this->queryFieldService, $location, $fieldDefinitionIdentifier
@@ -137,12 +132,12 @@ final class QueryResultsInjector implements EventSubscriberInterface
 
             return $pager;
         } else {
-            if ($this->queryFieldService instanceof QueryFieldLocationService && isset($location)) {
+            if ($this->queryFieldService instanceof QueryFieldLocationService && $location !== null) {
                 return $this->queryFieldService->loadContentItemsForLocation(
                     $location,
                     $fieldDefinitionIdentifier
                 );
-            } elseif (isset($content)) {
+            } elseif ($content !== null) {
                 return $this->queryFieldService->loadContentItems(
                     $content,
                     $fieldDefinitionIdentifier

--- a/src/eZ/ContentView/QueryResultsWithLocationPagerFantaAdapter.php
+++ b/src/eZ/ContentView/QueryResultsWithLocationPagerFantaAdapter.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformQueryFieldType\eZ\ContentView;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use EzSystems\EzPlatformQueryFieldType\API\QueryFieldLocationService;
+use Pagerfanta\Adapter\AdapterInterface;
+
+final class QueryResultsWithLocationPagerFantaAdapter implements AdapterInterface
+{
+    /** @var \EzSystems\EzPlatformQueryFieldType\API\QueryFieldLocationService */
+    private $queryFieldService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    private $location;
+
+    /** @var string */
+    private $fieldDefinitionIdentifier;
+
+    public function __construct(
+        QueryFieldLocationService $queryFieldService,
+        Location $location,
+        string $fieldDefinitionIdentifier)
+    {
+        $this->queryFieldService = $queryFieldService;
+        $this->location = $location;
+        $this->fieldDefinitionIdentifier = $fieldDefinitionIdentifier;
+    }
+
+    public function getNbResults()
+    {
+        return $this->queryFieldService->countContentItemsForLocation(
+            $this->location,
+            $this->fieldDefinitionIdentifier
+        );
+    }
+
+    public function getSlice($offset, $length)
+    {
+        return $this->queryFieldService->loadContentItemsSliceForLocation(
+            $this->location,
+            $this->fieldDefinitionIdentifier,
+            $offset,
+            $length
+        );
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31659](https://jira.ez.no/browse/EZP-31659)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v2.x`, `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes/no
| **Doc needed**                       | yes

Introduces a new `QueryFieldLocationService` that allow to get results / results slices / count results based on a location. With the previous methods, only `mainLocation` was available as a variable, since it was inferred from the content.

Now both can be available, and `location` will be set to the "current" location. In the context of a content view, it will be the requested location's. For REST and GraphQL, parameters will be added to specify which location should be used.

#### TODO
- [x] Implement `PagerFantaAdapter`
- [x] Implement in `QueryResultsInjector`
- [x] Implement in the REST controller
- [x] Implement in GraphQL

#### Checklist
- [X] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
