### PR TITLE
EZP-31676: keep the offset defined in the query

### DIFF
--- a/spec/API/QueryFieldServiceSpec.php
+++ b/spec/API/QueryFieldServiceSpec.php
@@ -3,6 +3,7 @@
 namespace spec\EzSystems\EzPlatformQueryFieldType\API;
 
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Query as ApiContentQuery;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldService;
 use EzSystems\EzPlatformQueryFieldType\FieldType\Query;
 use eZ\Publish\API\Repository\ContentTypeService;
@@ -77,6 +78,32 @@ class QueryFieldServiceSpec extends ObjectBehavior
     function it_counts_items_from_a_query_field_for_a_given_content_item()
     {
         $this->countContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe($this->totalCount);
+    }
+
+    function it_deducts_any_offset_when_counting_results(QueryType $queryType, SearchService $searchService)
+    {
+        $query = new ApiContentQuery();
+        $query->offset = 5;
+
+        $searchResult = new SearchResult(['searchHits' => [], 'totalCount' => 7]);
+
+        $searchService->findContent($query)->willReturn($searchResult);
+        $queryType->getQuery(Argument::any())->willReturn($query);
+
+        $this->countContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe(2);
+    }
+
+    function it_returns_zero_if_offset_is_bigger_than_count(QueryType $queryType, SearchService $searchService)
+    {
+        $query = new ApiContentQuery();
+        $query->offset = 8;
+
+        $searchResult = new SearchResult(['searchHits' => [], 'totalCount' => 5]);
+
+        $searchService->findContent($query)->willReturn($searchResult);
+        $queryType->getQuery(Argument::any())->willReturn($query);
+
+        $this->countContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe(0);
     }
 
     /**

--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -72,13 +72,15 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldP
         $query = $this->prepareQuery($content, $fieldDefinitionIdentifier);
         $query->limit = 0;
 
-        return $this->searchService->findContent($query)->totalCount;
+        $count = $this->searchService->findContent($query)->totalCount - $query->offset;
+
+        return $count < 0 ? 0 : $count;
     }
 
     public function loadContentItemsSlice(Content $content, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable
     {
         $query = $this->prepareQuery($content, $fieldDefinitionIdentifier);
-        $query->offset = $offset;
+        $query->offset += $offset;
         $query->limit = $limit;
 
         return array_map(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31676](https://jira.ez.no/browse/EZP-31676)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v2.5`, `v3.0`, `v3.1`
| **BC breaks**                          | maybe...
| **Tests pass**                          | yes
| **Doc needed**                       | yes

Handles any predefined offset in the query (through parameters or through the query type itself).

The predefined offset is added to the one used for pagination, and removed from the total count.