### PR TITLE
Pass the itemViewType parameter to the inner view template

### DIFF
--- a/src/eZ/ContentView/QueryResultsInjector.php
+++ b/src/eZ/ContentView/QueryResultsInjector.php
@@ -50,7 +50,7 @@ class QueryResultsInjector implements EventSubscriberInterface
 
         if ($viewType === $this->views['field']) {
             $parameters = [
-                'itemViewType' => $this->views['item'],
+                'itemViewType' => $event->getBuilderParameters()['itemViewType'] ?? $this->views['item'],
                 'items' => $this->buildResults($event),
             ];
             $parameters['isPaginationEnabled'] = ($parameters['items'] instanceof Pagerfanta);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31678](https://jira.ez.no/browse/EZP-31678)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`, `v3.0`, `v3.1`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

The documented `itemViewType` field template parameter is now passed on to the inner view so that items rendering can be customized as expected.

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
