### PR TITLE
[CS] Configured PHP CS Fixer for Spec tests

### DIFF
--- a/.php_cs.spec
+++ b/.php_cs.spec
@@ -1,0 +1,20 @@
+<?php
+
+$config = EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build();
+
+$config
+    ->setRules(
+        array_merge(
+            $config->getRules(),
+            [
+                'visibility_required' => false,
+            ]
+        )
+    )
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__ . '/spec')
+            ->files()->name('*.php')
+    );
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 
 script:
   - if [ "$TARGET" == "phpspec" ] ; then ./vendor/bin/phpspec run --format=pretty; fi
-  - if [ "$TARGET" == "codestyle" ] ; then ./vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=estimating; fi
+  - if [ "$TARGET" == "codestyle" ] ; then ./vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=estimating && ./vendor/bin/php-cs-fixer fix --config=.php_cs.spec --dry-run -v --show-progress=estimating; fi
 
 notifications:
   slack:

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,12 @@
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16.0"
     },
+    "scripts": {
+        "fix-cs": [
+            "php-cs-fixer --ansi fix -v --show-progress=estimating",
+            "php-cs-fixer --ansi fix --config=.php_cs.spec -v --show-progress=estimating"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/spec/API/QueryFieldServiceSpec.php
+++ b/spec/API/QueryFieldServiceSpec.php
@@ -1,10 +1,13 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace spec\EzSystems\EzPlatformQueryFieldType\API;
 
 use eZ\Publish\API\Repository\LocationService;
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldService;
-use EzSystems\EzPlatformQueryFieldType\FieldType\Query;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -13,7 +16,6 @@ use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\QueryType\QueryType;
 use eZ\Publish\Core\QueryType\QueryTypeRegistry;
 use eZ\Publish\Core\Repository\Values;
-use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -51,7 +53,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
                         'ReturnedType' => 'folder',
                         'QueryType' => self::QUERY_TYPE_IDENTIFIER,
                         'Parameters' => $parameters,
-                    ]
+                    ],
                 ]),
             ],
         ]);
@@ -87,7 +89,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
         return new Values\Content\Content([
             'versionInfo' => new Values\Content\VersionInfo([
                 'contentInfo' => new ContentInfo(['contentTypeId' => self::CONTENT_TYPE_ID]),
-            ])
+            ]),
         ]);
     }
 }

--- a/spec/GraphQL/ContentQueryFieldDefinitionMapperSpec.php
+++ b/spec/GraphQL/ContentQueryFieldDefinitionMapperSpec.php
@@ -1,10 +1,13 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace spec\EzSystems\EzPlatformQueryFieldType\GraphQL;
 
 use EzSystems\EzPlatformQueryFieldType\GraphQL\ContentQueryFieldDefinitionMapper;
 use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\Core\QueryType\QueryTypeRegistry;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
@@ -22,8 +25,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
         FieldDefinitionMapper $innerMapper,
         NameHelper $nameHelper,
         ContentTypeService $contentTypeService
-    )
-    {
+    ) {
         $contentType = new ContentType(['identifier' => self::RETURNED_CONTENT_TYPE_IDENTIFIER]);
 
         $contentTypeService
@@ -109,8 +111,8 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
             'fieldTypeIdentifier' => self::FIELD_TYPE_IDENTIFIER,
             'fieldSettings' => [
                 'ReturnedType' => self::RETURNED_CONTENT_TYPE_IDENTIFIER,
-                'EnablePagination' => $enablePagination
-             ]
+                'EnablePagination' => $enablePagination,
+             ],
         ]);
     }
 

--- a/spec/GraphQL/QueryFieldResolverSpec.php
+++ b/spec/GraphQL/QueryFieldResolverSpec.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace spec\EzSystems\EzPlatformQueryFieldType\GraphQL;
 
 use EzSystems\EzPlatformQueryFieldType\API\QueryFieldServiceInterface;

--- a/spec/eZ/ContentView/QueryResultsInjectorSpec.php
+++ b/spec/eZ/ContentView/QueryResultsInjectorSpec.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace spec\EzSystems\EzPlatformQueryFieldType\eZ\ContentView;
 
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
@@ -32,8 +36,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
         ParameterBagInterface $parameterBag,
         ContentView $view,
         RequestStack $requestStack
-    )
-    {
+    ) {
         $this->beConstructedWith($queryFieldService, self::VIEWS, $requestStack);
         $event->getView()->willReturn($view);
         $view->getContent()->willReturn($this->createContentItem());
@@ -42,7 +45,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
             [
                 'queryFieldDefinitionIdentifier' => self::FIELD_DEFINITION_IDENTIFIER,
                 'enablePagination' => false,
-                'disablePagination' => false
+                'disablePagination' => false,
             ]
         );
     }
@@ -50,8 +53,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     function it_throws_an_InvalidArgumentException_if_no_item_view_is_provided(
         QueryFieldServiceInterface $queryFieldService,
         RequestStack $requestStack
-    )
-    {
+    ) {
         $this->beConstructedWith($queryFieldService, ['field' => self::FIELD_VIEW], $requestStack);
         $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
     }
@@ -59,8 +61,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     function it_throws_an_InvalidArgumentException_if_no_field_view_is_provided(
         QueryFieldServiceInterface $queryFieldService,
         RequestStack $requestStack
-    )
-    {
+    ) {
         $this->beConstructedWith($queryFieldService, ['item' => 'field'], $requestStack);
         $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
     }
@@ -95,7 +96,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
             [
                 'itemViewType' => self::ITEM_VIEW,
                 'items' => $this->getResults(),
-                'isPaginationEnabled' => false
+                'isPaginationEnabled' => false,
             ]
         )->shouldBeCalled();
 
@@ -105,9 +106,9 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     function getMatchers(): array
     {
         return [
-            'subscribeTo' => function($return, $event) {
+            'subscribeTo' => function ($return, $event) {
                 return is_array($return) && isset($return[$event]);
-            }
+            },
         ];
     }
 

--- a/spec/eZ/Persistence/Legacy/Content/FieldValue/Converter/QueryConverterSpec.php
+++ b/spec/eZ/Persistence/Legacy/Content/FieldValue/Converter/QueryConverterSpec.php
@@ -1,9 +1,12 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace spec\EzSystems\EzPlatformQueryFieldType\eZ\Persistence\Legacy\Content\FieldValue\Converter;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use EzSystems\EzPlatformQueryFieldType\eZ\Persistence\Legacy\Content\FieldValue\Converter\QueryConverter;
 use PhpSpec\ObjectBehavior;
@@ -38,7 +41,7 @@ class QueryConverterSpec extends ObjectBehavior
 
     function getStorageDefinition(): StorageFieldDefinition
     {
-        $fieldDefinition = new StorageFieldDefinition;
+        $fieldDefinition = new StorageFieldDefinition();
         $fieldDefinition->dataText5 = \json_encode(self::PARAMETERS);
         $fieldDefinition->dataText1 = self::QUERY_TYPE;
         $fieldDefinition->dataText2 = self::RETURNED_TYPE;


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Target branch** | 1.0 for eZ Platform 2.5 LTS CI CS setup |
| **Failing build** | [Travis job 349271347](https://travis-ci.com/github/ezsystems/ezplatform-query-fieldtype/jobs/349271347#L462-L466)

Looks like we're one rule apart from applying some automation to CS checks for `spec` directory containing Spec tests. It's important that we automate those checks.

The difference in Spec tests, compared to production code is lack of `public` in testing method signature. The reason for that is that those method signatures are already long.

Applying rules for specific paths is not possible (see feature requests: FriendsOfPHP/PHP-CS-Fixer#3126 and FriendsOfPHP/PHP-CS-Fixer#3871) so I've introduced separate config for Travis to run.

I've also added `composer fix-cs` command for local use. Travis is still gonna use explicit command calls because they require `--dry-run` to be passed. ~Or should I ignore `--dry-run` and just use `composer fix-cs`? It's gonna modify the files inside Travis container.~ // not possible because error code is not passed to Travis by Composer for multiple calls in one command.

### TODO
- [x] Fix outstanding issues after confirming Travis reports them correctly