### PR TITLE
[Composer] Added ezplatform-search dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "ezsystems/ez-support-tools": "^2.0@dev",
         "ezsystems/ezplatform-design-engine": "^3.0@dev",
         "ezsystems/ezplatform-richtext": "^2.0@dev",
+        "ezsystems/ezplatform-search": "^1.0@dev",
         "ezsystems/ezplatform-user": "^2.0@dev",
         "phpspec/phpspec": "^6.0",
         "ezsystems/ezplatform-code-style": "^0.1.0",


### PR DESCRIPTION
Failing build: https://travis-ci.com/ezsystems/ezplatform-query-fieldtype/builds/171629039

Admin-ui has a dependency on ezplatform-search which is not available in a stable version and needs to be added explicitly.