### PR TITLE
Made GraphQL optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "ext-json": "*",
         "ezsystems/ezplatform-admin-ui": "^2.0@dev",
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
-        "ezsystems/ezplatform-graphql": "^2.0@dev",
         "ezsystems/ezplatform-rest": "^1.0@dev",
         "ezsystems/ezplatform-kernel": "^1.0@dev",
         "symfony/dependency-injection": "^5.0",
@@ -29,6 +28,9 @@
         "symfony/translation": "^5.0",
         "symfony/yaml": "^5.0",
         "psr/log": "^1.1"
+    },
+    "suggest": {
+        "ezsystems/ezplatform-graphql": "^2.0@dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/DependencyInjection/EzSystemsEzPlatformQueryFieldTypeExtension.php
+++ b/src/Symfony/DependencyInjection/EzSystemsEzPlatformQueryFieldTypeExtension.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformQueryFieldType\Symfony\DependencyInjection;
 
+use EzSystems\EzPlatformGraphQL\DependencyInjection\EzSystemsEzPlatformGraphQLExtension;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -24,9 +25,15 @@ final class EzSystemsEzPlatformQueryFieldTypeExtension extends Extension impleme
         );
 
         $loader->load('default_parameters.yaml');
-        $loader->load('services.yaml');
         if (!$container->hasParameter('kernel.debug') || !$container->getParameter('kernel.debug')) {
             $loader->load('prod/services.yaml');
+        }
+
+        $loader->load('services/ezplatform.yaml');
+        $loader->load('services/services.yaml');
+
+        if ($container->hasExtension('ezplatform_graphql')) {
+            $loader->load('services/graphql.yaml');
         }
 
         $this->addContentViewConfig($container);

--- a/src/Symfony/Resources/config/services.yaml
+++ b/src/Symfony/Resources/config/services.yaml
@@ -1,4 +1,0 @@
-imports:
-    - { resource: services/ezplatform.yaml }
-    - { resource: services/graphql.yaml }
-    - { resource: services/services.yaml }


### PR DESCRIPTION
Only loads GraphQL services if GraphQL is enabled. Made `ezsystems/ezplatform-graphql` a suggested requirement. Not sure about it, since it doesn't enforce a version. It would imply version checks for the GraphQL aspect of the feature, or making GraphQL a 3rd party package (or a split)...