### PR TITLE
EZP-32326: Re-introduced query type offset

### DIFF
--- a/src/API/QueryFieldService.php
+++ b/src/API/QueryFieldService.php
@@ -86,7 +86,7 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
     public function loadContentItemsSlice(Content $content, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable
     {
         $query = $this->prepareQuery($content, $content->contentInfo->getMainLocation(), $fieldDefinitionIdentifier);
-        $query->offset = $offset;
+        $query->offset += $offset;
         $query->limit = $limit;
 
         return $this->executeQueryAndMapResult($query);
@@ -95,7 +95,7 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
     public function loadContentItemsSliceForLocation(Location $location, string $fieldDefinitionIdentifier, int $offset, int $limit): iterable
     {
         $query = $this->prepareQuery($location->getContent(), $location, $fieldDefinitionIdentifier);
-        $query->offset = $offset;
+        $query->offset += $offset;
         $query->limit = $limit;
 
         return $this->executeQueryAndMapResult($query);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-32326](https://issues.ibexa.co/browse/EZP-32326)
| **Type**                                   | bug
| **Target eZ Platform version** | Package: v2.3.1, product: v3.3.1
| **BC breaks**                          | no
| **Doc needed**                       | no

Any offset defined in the query type must be kept when computing offset for pagination. It was the case before, but the lines got lost when the location pull-request was merged.