### PR TITLE
[CI] Added job for wrong target branch detection

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,12 @@
+name: PR check
+on:
+  pull_request:
+    types: 
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+jobs:
+  test-base-branch:
+    uses: ibexa/gh-workflows/.github/workflows/pr-check.yml@main


### PR DESCRIPTION
Adding a job checking the correctnes of base branch in Pull Request, this time as a reusable workflow.
It uses ibexa/gh-workflows#1 under the hood.
Previous PRs: #1889, #1954